### PR TITLE
Add dismissible Terms of Service banner and update TOS

### DIFF
--- a/internal/embed/html/bases/base.html
+++ b/internal/embed/html/bases/base.html
@@ -25,6 +25,33 @@
             background-color: #fc0;
             margin: 0px -48px 0;
             padding: 32px 48px 32px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        
+        .notification-content {
+            flex: 1;
+        }
+        
+        .dismiss-btn {
+            background: none;
+            border: none;
+            cursor: pointer;
+            font-size: 24px;
+            font-weight: bold;
+            color: #333;
+            padding: 0;
+            margin-left: 16px;
+            opacity: 0.7;
+        }
+        
+        .dismiss-btn:hover {
+            opacity: 1;
+        }
+        
+        .notification.hidden {
+            display: none;
         }
 
         .github-btn {
@@ -199,6 +226,12 @@
         {{block "nav" .}}{{end}}
     </nav>
     {{ block "postheader" .}}{{end}}
+    <section class="notification" id="website-banner">
+        <div class="notification-content">
+            We have updated our Terms of Service to clarify service access policies. By continuing to use the Service, you agree to these updated terms. You can review the terms at <a href="/tos">https://iwasintheoffice.com/tos</a>
+        </div>
+        <button class="dismiss-btn" onclick="dismissBanner()" aria-label="Dismiss notification">&times;</button>
+    </section>
     <h2>{{block "title" .}}{{end}}</h2>
     <section>{{block "content" .}}{{end}}<section>
 </main>
@@ -357,7 +390,35 @@ function fetchMelbourneWeather(timeBasedEnabled) {
         });
 }
 
+// Banner management
+function dismissBanner() {
+    const banner = document.getElementById('website-banner');
+    banner.classList.add('hidden');
+    
+    // Set cookie to remember dismissal for 30 days
+    const expiryDate = new Date();
+    expiryDate.setTime(expiryDate.getTime() + (30 * 24 * 60 * 60 * 1000));
+    document.cookie = "banner_dismissed=true; expires=" + expiryDate.toUTCString() + "; path=/; SameSite=Lax";
+}
+
+function checkBannerDismissal() {
+    const cookies = document.cookie.split(';');
+    const bannerDismissed = cookies.some(cookie => 
+        cookie.trim().startsWith('banner_dismissed=true')
+    );
+    
+    if (bannerDismissed) {
+        const banner = document.getElementById('website-banner');
+        if (banner) {
+            banner.classList.add('hidden');
+        }
+    }
+}
+
 // Initialize theme when page loads
-document.addEventListener('DOMContentLoaded', initializeTheme);
+document.addEventListener('DOMContentLoaded', function() {
+    initializeTheme();
+    checkBannerDismissal();
+});
 </script>
 </html>

--- a/internal/embed/html/tos.html
+++ b/internal/embed/html/tos.html
@@ -18,45 +18,51 @@
 </div>
 
 <div class="section">
-    <h2>4. Acceptable Use</h2>
-    <p>4.1. You agree not to:</p>
+    <h2>4. Service Availability and Access</h2>
+    <p>4.1. This Service is primarily intended for a specific user community. While we welcome broader usage, we do not guarantee continued access or service availability to users outside of our intended community.</p>
+    <p>4.2. Access to the Service may be limited or restricted for users outside of our intended user community.</p>
+</div>
+
+<div class="section">
+    <h2>5. Acceptable Use</h2>
+    <p>5.1. You agree not to:</p>
     <ul>
         <li>Use the Service in any unlawful manner</li>
         <li>Attempt to gain unauthorized access to the Service</li>
         <li>Interfere with or disrupt the Service</li>
         <li>Use the Service in any malicious manner</li>
     </ul>
-    <p>4.2. We reserve the right to terminate your access to the Service for violations of these Terms.</p>
+    <p>5.2. We reserve the right to terminate your access to the Service for violations of these Terms.</p>
 </div>
 
 <div class="section">
-    <h2>5. Data Input</h2>
-    <p>5.1. You acknowledge that the Service's statistics and calculations are based on the data you provide.</p>
+    <h2>6. Data Input</h2>
+    <p>6.1. You acknowledge that the Service's statistics and calculations are based on the data you provide.</p>
 </div>
 
 <div class="section">
-    <h2>6. Modifications to Service</h2>
-    <p>6.1. We reserve the right to modify or discontinue the Service at any time, with or without notice.</p>
-    <p>6.2. We shall not be liable to you or any third party for any modification, suspension, or discontinuance of the Service.</p>
+    <h2>7. Modifications to Service</h2>
+    <p>7.1. We reserve the right to modify or discontinue the Service at any time, with or without notice.</p>
+    <p>7.2. We shall not be liable to you or any third party for any modification, suspension, or discontinuance of the Service.</p>
 </div>
 
 <div class="section">
-    <h2>7. Disclaimer of Warranties</h2>
+    <h2>8. Disclaimer of Warranties</h2>
     <p>THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT ANY WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED.</p>
 </div>
 
 <div class="section">
-    <h2>8. Limitation of Liability</h2>
+    <h2>9. Limitation of Liability</h2>
     <p>IN NO EVENT SHALL WE BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING OUT OF OR RELATING TO YOUR USE OF THE SERVICE.</p>
 </div>
 
 <div class="section">
-    <h2>9. Changes to Terms</h2>
+    <h2>10. Changes to Terms</h2>
     <p>We reserve the right to update these Terms at any time. Continued use of the Service after any changes constitutes acceptance of the new Terms.</p>
 </div>
 
 <div class="section">
-    <h2>10. Contact</h2>
+    <h2>11. Contact</h2>
     <p>For questions about these terms, please contact <a href="mailto:contact@iwasintheoffice.com">contact@iwasintheoffice.com</a></p>
 </div>
 {{ end }}


### PR DESCRIPTION
## Summary
- Add dismissible banner notifying users about Terms of Service updates
- Implement cookie-based persistence for banner dismissal (30-day expiration)
- Add new section 4 to TOS regarding service availability and access policies
- Renumber all subsequent TOS sections accordingly

## Changes Made
### Banner Implementation
- Added dismissible notification banner to base template
- Banner appears on all pages with clear messaging about TOS updates
- Implemented dismiss functionality with cookie persistence (30-day expiration)
- Added responsive styling that works with existing theme system

### Terms of Service Updates
- Added new section 4: "Service Availability and Access"
  - 4.1: Service primarily intended for specific user community
  - 4.2: Access may be limited for users outside intended community
- Renumbered all subsequent sections (5-11) to maintain proper numbering

## Test Plan
- [ ] Verify banner appears on all pages
- [ ] Test dismiss functionality works correctly
- [ ] Confirm cookie persistence prevents banner from reappearing
- [ ] Check TOS page displays updated terms with correct numbering
- [ ] Test banner styling across different themes

🤖 Generated with [Claude Code](https://claude.ai/code)