### PR TITLE
Use PAT for automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -27,4 +27,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.APPROVER_PAT }}


### PR DESCRIPTION
Default token doesn't trigger github actions on merge -> use PAT instead