### PR TITLE
Add dismissible banner functionality to feedback survey

### DIFF
--- a/internal/embed/html/form.html
+++ b/internal/embed/html/form.html
@@ -1,9 +1,31 @@
 {{ template "base.html" . }}
 {{ define "postheader" }}
-<section class="notification">
-    <strong>📊 Help us improve Officetracker!</strong><br>
-    Please take a moment to fill out our <a href="https://forms.office.com/r/aqcpVBUWFH" target="_blank" style="color: #000; text-decoration: underline;">user feedback survey</a>.
+<section class="notification" id="feedback-banner" style="display: none;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <div>
+            <strong>📊 Help us improve Officetracker!</strong><br>
+            Please take a moment to fill out our <a href="https://forms.office.com/r/aqcpVBUWFH" target="_blank" style="color: #000; text-decoration: underline;">user feedback survey</a>.
+        </div>
+        <button id="dismiss-banner" style="background: none; border: none; font-size: 1.2em; cursor: pointer; padding: 0 0 0 10px;" aria-label="Dismiss banner">✕</button>
+    </div>
 </section>
+<script>
+// Check if banner was previously dismissed
+if (!document.cookie.split('; ').find(row => row.startsWith('feedback-banner-dismissed='))) {
+    document.getElementById('feedback-banner').style.display = 'block';
+}
+
+// Add dismiss functionality
+document.getElementById('dismiss-banner').addEventListener('click', function() {
+    // Set cookie to remember dismissal (expires in 1 year)
+    const expires = new Date();
+    expires.setFullYear(expires.getFullYear() + 1);
+    document.cookie = 'feedback-banner-dismissed=true; expires=' + expires.toUTCString() + '; path=/';
+    
+    // Hide the banner
+    document.getElementById('feedback-banner').style.display = 'none';
+});
+</script>
 {{ end }}
 {{ define "content" }}
 <div id="calendar-nav">


### PR DESCRIPTION
## Summary
- Added a dismiss button (✕) to the feedback survey banner on the homepage
- Implemented cookie-based dismissal that persists for 1 year
- Banner is now hidden by default and only shows if not previously dismissed
- Clean UI design with accessible dismiss button

## Test plan
- [x] Banner displays on fresh page load (no dismissal cookie)
- [x] Dismiss button hides the banner immediately when clicked
- [x] Cookie is set with 1-year expiration when banner is dismissed
- [x] Banner remains hidden on page refresh after dismissal
- [x] Dismiss button is accessible and properly styled

## Implementation Details
The implementation uses vanilla JavaScript with cookies to store the dismissal state. The banner uses flexbox layout to position the dismiss button and maintains the existing yellow notification styling.

🤖 Generated with [Claude Code](https://claude.ai/code)