### PR TITLE
Add debug cookie detection to request context

### DIFF
--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	userCookie = "user"
-	demoUserId = "42069"
+	userCookie  = "user"
+	debugCookie = "debug"
+	demoUserId  = "42069"
 )
 
 type Method int

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -11,6 +11,7 @@ const (
 	CtxKey           = "ctx"
 	CtxUserIDKey     = "userID"
 	CtxAuthMethodKey = "auth"
+	CtxDebugKey      = "debug"
 )
 
 func MapCtx(ctx context.Context) CtxValue {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -205,6 +205,14 @@ func getAuthMethod(r *http.Request) (auth.Method, error) {
 	return authMethod, nil
 }
 
+func getDebug(r *http.Request) bool {
+	debug, ok := context.GetCtxValue(r).Get(context.CtxDebugKey).(bool)
+	if !ok {
+		return false
+	}
+	return debug
+}
+
 func populateUserID[T any](req *T, r *http.Request) error {
 	v := reflect.ValueOf(req).Elem()
 	t := v.Type()


### PR DESCRIPTION
## Summary
- Adds detection for a `debug=true` cookie similar to how auth method is stored in request context
- Makes debug state available through convenience functions throughout the application
- Includes debug state in request logging for better observability

## Changes
- **Context**: Add `CtxDebugKey` constant to context package for storing debug state
- **Auth**: Add `GetDebug()` function to detect and parse debug cookie value
- **Middleware**: Inject debug state into request context in `injectAuth` middleware
- **API**: Add `getDebug()` convenience function for extracting debug state from requests  
- **Logging**: Include debug state in request logging output

## Test plan
- [ ] Set cookie `debug=true` in browser and verify debug state is detected
- [ ] Verify debug state appears in request logs when enabled
- [ ] Test that debug state defaults to false when cookie is missing or has other values
- [ ] Ensure existing functionality remains unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)