### PR TITLE
Make tracking year start month configurable

### DIFF
--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -23,10 +23,10 @@ type Databaser interface {
 	GetDay(userID int, day int, month int, year int) (model.DayState, error)
 	SaveMonth(userID int, month int, year int, state model.MonthState) error
 	GetMonth(userID int, month int, year int) (model.MonthState, error)
-	GetYear(userID int, year int) (model.YearState, error)
+	GetYear(userID int, year int, startMonth int) (model.YearState, error)
 	SaveNote(userID int, month int, year int, note string) error
 	GetNote(userID int, month int, year int) (model.Note, error)
-	GetNotes(userID int, year int) (map[int]model.Note, error)
+	GetNotes(userID int, year int, startMonth int) (map[int]model.Note, error)
 
 	GetUserByGHID(ghID string) (int, error)
 	GetUserBySecret(secret string) (int, error)
@@ -41,6 +41,8 @@ type Databaser interface {
 	SaveThemePreferences(userID int, prefs model.ThemePreferences) error
 	GetSchedulePreferences(userID int) (model.SchedulePreferences, error)
 	SaveSchedulePreferences(userID int, prefs model.SchedulePreferences) error
+	GetCalendarPreferences(userID int) (model.CalendarPreferences, error)
+	SaveCalendarPreferences(userID int, prefs model.CalendarPreferences) error
 
 	SaveSecret(userID int, secret string, name string) error
 	ListActiveTokens(userID int) ([]TokenMetadata, error)

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/baely/officetracker/internal/config"
+	"github.com/baely/officetracker/internal/util"
 	"github.com/baely/officetracker/pkg/model"
 )
 
@@ -103,13 +104,15 @@ func (p *postgres) GetMonth(userID int, month int, year int) (model.MonthState, 
 	return monthState, err
 }
 
-func (p *postgres) GetYear(userID int, year int) (model.YearState, error) {
-	q := `SELECT month, day, state FROM entries WHERE user_id = $1 AND ((year = $2 AND month > 9) OR (year = $3 AND month <= 9));`
+func (p *postgres) GetYear(userID int, year int, startMonth int) (model.YearState, error) {
+	startMonth = util.NormaliseStartMonth(startMonth)
+	firstYear, secondYear := util.TrackingYearCalendarYears(year, startMonth)
+	q := `SELECT month, day, state FROM entries WHERE user_id = $1 AND ((year = $2 AND month >= $4) OR (year = $3 AND month < $4));`
 	yearState := model.YearState{
 		Months: make(map[int]model.MonthState),
 	}
 	err := p.readOnlyTransaction(func(tx *sql.Tx) error {
-		rows, err := tx.Query(q, userID, year-1, year)
+		rows, err := tx.Query(q, userID, firstYear, secondYear, startMonth)
 		if err != nil {
 			return err
 		}
@@ -156,11 +159,13 @@ func (p *postgres) GetNote(userID int, month int, year int) (model.Note, error) 
 	return noteModel, err
 }
 
-func (p *postgres) GetNotes(userID int, year int) (map[int]model.Note, error) {
-	q := `SELECT month, notes FROM notes WHERE user_id = $1 AND ((year = $2 AND month > 9) OR (year = $3 AND month <= 9));`
+func (p *postgres) GetNotes(userID int, year int, startMonth int) (map[int]model.Note, error) {
+	startMonth = util.NormaliseStartMonth(startMonth)
+	firstYear, secondYear := util.TrackingYearCalendarYears(year, startMonth)
+	q := `SELECT month, notes FROM notes WHERE user_id = $1 AND ((year = $2 AND month >= $4) OR (year = $3 AND month < $4));`
 	notes := make(map[int]model.Note)
 	err := p.readOnlyTransaction(func(tx *sql.Tx) error {
-		rows, err := tx.Query(q, userID, year-1, year)
+		rows, err := tx.Query(q, userID, firstYear, secondYear, startMonth)
 		if err != nil {
 			return err
 		}
@@ -500,6 +505,42 @@ func (p *postgres) SaveSchedulePreferences(userID int, prefs model.SchedulePrefe
 	return p.readWriteTransaction(func(tx *sql.Tx) error {
 		_, err := tx.Exec(q, userID, int(prefs.Monday), int(prefs.Tuesday), int(prefs.Wednesday),
 			int(prefs.Thursday), int(prefs.Friday), int(prefs.Saturday), int(prefs.Sunday))
+		return err
+	})
+}
+
+func (p *postgres) GetCalendarPreferences(userID int) (model.CalendarPreferences, error) {
+	q := `SELECT tracking_year_start_month FROM user_preferences WHERE user_id = $1;`
+	prefs := model.CalendarPreferences{TrackingYearStartMonth: model.DefaultTrackingYearStartMonth}
+
+	err := p.readOnlyTransaction(func(tx *sql.Tx) error {
+		row := tx.QueryRow(q, userID)
+		var startMonth sql.NullInt64
+		err := row.Scan(&startMonth)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if startMonth.Valid {
+			prefs.TrackingYearStartMonth = util.NormaliseStartMonth(int(startMonth.Int64))
+		}
+		return nil
+	})
+
+	return prefs, err
+}
+
+func (p *postgres) SaveCalendarPreferences(userID int, prefs model.CalendarPreferences) error {
+	startMonth := util.NormaliseStartMonth(prefs.TrackingYearStartMonth)
+	q := `INSERT INTO user_preferences (user_id, tracking_year_start_month)
+		  VALUES ($1, $2)
+		  ON CONFLICT (user_id)
+		  DO UPDATE SET tracking_year_start_month = $2;`
+
+	return p.readWriteTransaction(func(tx *sql.Tx) error {
+		_, err := tx.Exec(q, userID, startMonth)
 		return err
 	})
 }

--- a/internal/database/postgres/migrations/009-tracking-year-start.sql
+++ b/internal/database/postgres/migrations/009-tracking-year-start.sql
@@ -1,0 +1,4 @@
+-- Add the configurable tracking year start month to user_preferences.
+-- 10 = October, matching the original hardcoded behaviour.
+ALTER TABLE "user_preferences"
+ADD COLUMN IF NOT EXISTS "tracking_year_start_month" INTEGER NOT NULL DEFAULT 10;

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/baely/officetracker/internal/config"
+	"github.com/baely/officetracker/internal/util"
 	"github.com/baely/officetracker/pkg/model"
 )
 
@@ -106,9 +107,11 @@ func (s *sqliteClient) GetMonth(_ int, month int, year int) (model.MonthState, e
 	return monthState, nil
 }
 
-func (s *sqliteClient) GetYear(_ int, year int) (model.YearState, error) {
-	q := `SELECT Day, Month, State FROM entries WHERE ((Year = ? AND Month > 9) OR (Year = ? AND Month <= 9));`
-	rows, err := s.db.Query(q, year-1, year)
+func (s *sqliteClient) GetYear(_ int, year int, startMonth int) (model.YearState, error) {
+	startMonth = util.NormaliseStartMonth(startMonth)
+	firstYear, secondYear := util.TrackingYearCalendarYears(year, startMonth)
+	q := `SELECT Day, Month, State FROM entries WHERE ((Year = ? AND Month >= ?) OR (Year = ? AND Month < ?));`
+	rows, err := s.db.Query(q, firstYear, startMonth, secondYear, startMonth)
 	if err != nil {
 		return model.YearState{}, err
 	}
@@ -151,9 +154,11 @@ func (s *sqliteClient) GetNote(_ int, month int, year int) (model.Note, error) {
 	return note, err
 }
 
-func (s *sqliteClient) GetNotes(_ int, year int) (map[int]model.Note, error) {
-	q := `SELECT Month, Notes FROM notes WHERE ((Year = ? AND Month > 9) OR (Year = ? AND Month <= 9));`
-	rows, err := s.db.Query(q, year-1, year)
+func (s *sqliteClient) GetNotes(_ int, year int, startMonth int) (map[int]model.Note, error) {
+	startMonth = util.NormaliseStartMonth(startMonth)
+	firstYear, secondYear := util.TrackingYearCalendarYears(year, startMonth)
+	q := `SELECT Month, Notes FROM notes WHERE ((Year = ? AND Month >= ?) OR (Year = ? AND Month < ?));`
+	rows, err := s.db.Query(q, firstYear, startMonth, secondYear, startMonth)
 	if err != nil {
 		return nil, err
 	}
@@ -403,6 +408,59 @@ func (s *sqliteClient) SaveSchedulePreferences(_ int, prefs model.SchedulePrefer
 		_, err = s.db.Exec(q, monday, tuesday, wednesday, thursday, friday, saturday, sunday)
 	}
 
+	return err
+}
+
+func (s *sqliteClient) GetCalendarPreferences(_ int) (model.CalendarPreferences, error) {
+	prefs := model.CalendarPreferences{TrackingYearStartMonth: model.DefaultTrackingYearStartMonth}
+
+	// Check if the preferences table exists; if not, return defaults.
+	q := `SELECT name FROM sqlite_master WHERE type='table' AND name='user_preferences';`
+	var tableName string
+	if err := s.db.QueryRow(q).Scan(&tableName); errors.Is(err, sql.ErrNoRows) {
+		return prefs, nil
+	}
+
+	// Make sure the column exists (ignore error if it already does).
+	s.db.Exec(`ALTER TABLE user_preferences ADD COLUMN tracking_year_start_month INTEGER DEFAULT 10;`)
+
+	q = `SELECT COALESCE(tracking_year_start_month, 10) FROM user_preferences LIMIT 1;`
+	var startMonth int
+	if err := s.db.QueryRow(q).Scan(&startMonth); err != nil {
+		// No row yet (or other read issue) - fall back to defaults.
+		return prefs, nil
+	}
+
+	prefs.TrackingYearStartMonth = util.NormaliseStartMonth(startMonth)
+	return prefs, nil
+}
+
+func (s *sqliteClient) SaveCalendarPreferences(_ int, prefs model.CalendarPreferences) error {
+	startMonth := util.NormaliseStartMonth(prefs.TrackingYearStartMonth)
+
+	// Make sure the table and column exist.
+	q := `CREATE TABLE IF NOT EXISTS user_preferences (
+        theme TEXT DEFAULT 'default',
+        weather_enabled INTEGER DEFAULT 0,
+        time_based_enabled INTEGER DEFAULT 0,
+        location TEXT DEFAULT NULL
+    );`
+	if _, err := s.db.Exec(q); err != nil {
+		return err
+	}
+	s.db.Exec(`ALTER TABLE user_preferences ADD COLUMN tracking_year_start_month INTEGER DEFAULT 10;`)
+
+	q = `SELECT COUNT(*) FROM user_preferences;`
+	var count int
+	if err := s.db.QueryRow(q).Scan(&count); err != nil {
+		return err
+	}
+
+	if count == 0 {
+		_, err := s.db.Exec(`INSERT INTO user_preferences (tracking_year_start_month) VALUES (?);`, startMonth)
+		return err
+	}
+	_, err := s.db.Exec(`UPDATE user_preferences SET tracking_year_start_month = ?;`, startMonth)
 	return err
 }
 

--- a/internal/embed/html/bases/form.js
+++ b/internal/embed/html/bases/form.js
@@ -2,6 +2,29 @@ const states = ["untracked", "present", "not present", "other", "scheduled-prese
 const monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September",
     "October", "November", "December"];
 
+// The month (1-12) the tracking year starts on, configurable per user.
+let trackingStartMonth = {{ .TrackingStartMonth }} || 10;
+
+// trackingYearForMonth0 maps a 0-indexed calendar month + calendar year to its
+// tracking-year label (mirrors util.TrackingYear in Go).
+function trackingYearForMonth0(month0, calYear) {
+    if (trackingStartMonth === 1) { return calYear; }
+    return month0 < (trackingStartMonth - 1) ? calYear : calYear + 1;
+}
+
+// calendarYearForMonth maps a 1-indexed calendar month to the calendar year it
+// falls in within the tracking year labelled fy (mirrors util.TrackingYearCalendarYears).
+function calendarYearForMonth(month1, fy) {
+    if (trackingStartMonth === 1) { return fy; }
+    return month1 >= trackingStartMonth ? fy - 1 : fy;
+}
+
+// trackingMonthOrder returns the position (0-11) of a 1-indexed month within the
+// tracking year.
+function trackingMonthOrder(month1) {
+    return (month1 - trackingStartMonth + 12) % 12;
+}
+
 class Summary {
     constructor(data, year) {
         this.updateYear(year, data);
@@ -85,7 +108,7 @@ class Summary {
         this.year = year;
         this.data = {};
         for (const [month, vals] of Object.entries(state)) {
-            let monthYear = month <= 9 ? year : year - 1;
+            let monthYear = calendarYearForMonth(parseInt(month), year);
             let key = formatDate(monthYear, parseInt(month) - 1);
             let stats = { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 };
             for (const [day, state] of Object.entries(vals)) {
@@ -110,7 +133,7 @@ class Data {
         this.state = state;
         this.notes = notes;
         this.updateDate(true, false);
-        let year = this.currentMonth < 9 ? this.currentYear : this.currentYear + 1;
+        let year = trackingYearForMonth0(this.currentMonth, this.currentYear);
         this.summary = new Summary(state, year);
         this.refreshDOM();
         Data.notesDOM.addEventListener("blur", () => { this.updateNote() });
@@ -160,7 +183,7 @@ class Data {
     drawSummary() { this.summary.refreshDOM(); }
 
     fetchData() {
-        let year = this.currentMonth < 9 ? this.currentYear : this.currentYear + 1;
+        let year = trackingYearForMonth0(this.currentMonth, this.currentYear);
         fetch("/api/v1/state/" + year)
             .then(r => r.json())
             .then(payload => {
@@ -171,7 +194,7 @@ class Data {
     }
 
     fetchNotes() {
-        let year = this.currentMonth < 9 ? this.currentYear : this.currentYear + 1;
+        let year = trackingYearForMonth0(this.currentMonth, this.currentYear);
         fetch("/api/v1/note/" + year)
             .then(r => r.json())
             .then(payload => {
@@ -259,7 +282,10 @@ class Data {
             this.currentYear++;
         }
         window.history.pushState({}, "", "/" + formatDate(this.currentYear, this.currentMonth));
-        let sameYear = !(this.currentMonth === 8 && delta === -1) && !(this.currentMonth === 9 && delta === 1);
+        // Detect crossing a tracking-year boundary (0-indexed first/last tracking months).
+        let firstMonth0 = (trackingStartMonth - 1) % 12;
+        let lastMonth0 = (trackingStartMonth - 2 + 12) % 12;
+        let sameYear = !(this.currentMonth === lastMonth0 && delta === -1) && !(this.currentMonth === firstMonth0 && delta === 1);
         this.updateDate(sameYear, true);
     }
 
@@ -289,7 +315,7 @@ class Data {
         if (csvButton.onclick) { csvButton.onclick = null; }
         if (pdfButton.onclick) { pdfButton.onclick = null; }
 
-        let year = this.currentMonth < 9 ? this.currentYear : this.currentYear + 1;
+        let year = trackingYearForMonth0(this.currentMonth, this.currentYear);
 
         csvButton.onclick = () => {
             window.location.href = "/api/v1/report/csv/" + year + "-attendance";
@@ -445,10 +471,8 @@ function calculateAllTimeTotal(currState, currentMonth, upToDay) {
 
     // Get all months from the state and sort them
     let months = Object.keys(currState).map(m => parseInt(m)).sort((a, b) => {
-        // Fiscal year ordering: Oct(10), Nov(11), Dec(12), Jan(1), Feb(2), etc.
-        let aOrder = a >= 10 ? a - 10 : a + 2;
-        let bOrder = b >= 10 ? b - 10 : b + 2;
-        return aOrder - bOrder;
+        // Order months within the tracking year (start month first).
+        return trackingMonthOrder(a) - trackingMonthOrder(b);
     });
 
     for (let m of months) {

--- a/internal/embed/html/settings.html
+++ b/internal/embed/html/settings.html
@@ -51,6 +51,32 @@
     </div>
 </div>
 
+<h3>Tracking Year</h3>
+<p>
+    Choose the month your tracking year starts on. The yearly summary and exported
+    reports are grouped into 12-month periods beginning on this month. Defaults to October.
+</p>
+
+<div class="theme-selector">
+    <div class="theme-option">
+        <label for="year-start-month">Year starts in:</label>
+        <select id="year-start-month">
+            <option value="1">January</option>
+            <option value="2">February</option>
+            <option value="3">March</option>
+            <option value="4">April</option>
+            <option value="5">May</option>
+            <option value="6">June</option>
+            <option value="7">July</option>
+            <option value="8">August</option>
+            <option value="9">September</option>
+            <option value="10">October</option>
+            <option value="11">November</option>
+            <option value="12">December</option>
+        </select>
+    </div>
+</div>
+
 <h3>Schedule</h3>
 <p>
     Select the days of the week you plan to attend the office on a recurring cycle.
@@ -102,10 +128,13 @@
             sunday: {{.SchedulePreferences.Sunday}}
         };
         
+        // Server-provided tracking-year start month (1-12)
+        const serverTrackingStartMonth = {{.CalendarPreferences.TrackingYearStartMonth}} || 10;
+
         // State names mapping
         const stateNames = {
             0: "Untracked",
-            1: "Work from Home", 
+            1: "Work from Home",
             2: "In office",
             3: "Other"
         };
@@ -125,6 +154,9 @@
         
         // Initialize schedule calendar
         initializeScheduleCalendar();
+
+        // Initialize tracking-year start month
+        initializeYearStartMonth();
         
         // Save settings function
         function saveSettings() {
@@ -225,6 +257,31 @@
             });
         }
         
+        // Initialize tracking-year start month selector with server data
+        function initializeYearStartMonth() {
+            const select = document.getElementById('year-start-month');
+            select.value = String(serverTrackingStartMonth);
+
+            select.addEventListener('change', function() {
+                const startMonth = parseInt(this.value, 10);
+                fetch('/api/v1/settings/calendar', {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        data: {
+                            tracking_year_start_month: startMonth
+                        }
+                    }),
+                    credentials: "include"
+                })
+                .catch(error => {
+                    console.error('Error saving tracking year settings:', error);
+                });
+            });
+        }
+
         // Event listener for theme change
         document.getElementById('theme-select').addEventListener('change', function() {
             toggleOptions(this.value);

--- a/internal/implementation/v1/report.go
+++ b/internal/implementation/v1/report.go
@@ -2,16 +2,18 @@ package v1
 
 import (
 	"fmt"
-	"time"
 
+	"github.com/baely/officetracker/internal/util"
 	"github.com/baely/officetracker/pkg/model"
 )
 
 func (i *Service) GetReport(req model.GetReportRequest) (model.Response, error) {
-	var start, end time.Time
+	startMonth, err := i.trackingStartMonth(req.Meta.UserID)
+	if err != nil {
+		return model.Response{}, err
+	}
 
-	start = time.Date(req.Meta.Year-1, time.October, 1, 0, 0, 0, 0, time.Local)
-	end = time.Date(req.Meta.Year, time.October, 1, 0, 0, 0, 0, time.Local)
+	start, end := util.TrackingYearRange(req.Meta.Year, startMonth)
 
 	report, err := i.reporter.GeneratePDF(req.Meta.UserID, req.Name, start, end)
 	if err != nil {
@@ -26,10 +28,12 @@ func (i *Service) GetReport(req model.GetReportRequest) (model.Response, error) 
 }
 
 func (i *Service) GetReportCSV(req model.GetReportCSVRequest) (model.Response, error) {
-	var start, end time.Time
+	startMonth, err := i.trackingStartMonth(req.Meta.UserID)
+	if err != nil {
+		return model.Response{}, err
+	}
 
-	start = time.Date(req.Meta.Year-1, time.October, 1, 0, 0, 0, 0, time.Local)
-	end = time.Date(req.Meta.Year, time.October, 1, 0, 0, 0, 0, time.Local)
+	start, end := util.TrackingYearRange(req.Meta.Year, startMonth)
 
 	report, err := i.reporter.GenerateCSV(req.Meta.UserID, start, end)
 	if err != nil {

--- a/internal/implementation/v1/settings.go
+++ b/internal/implementation/v1/settings.go
@@ -4,6 +4,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
+	"github.com/baely/officetracker/internal/util"
 	"github.com/baely/officetracker/pkg/model"
 )
 
@@ -46,10 +47,17 @@ func (i *Service) GetSettings(req model.GetSettingsRequest) (model.GetSettingsRe
 		return model.GetSettingsResponse{}, err
 	}
 
+	calendarPrefs, err := i.db.GetCalendarPreferences(req.Meta.UserID)
+	if err != nil {
+		return model.GetSettingsResponse{}, err
+	}
+	calendarPrefs.TrackingYearStartMonth = util.NormaliseStartMonth(calendarPrefs.TrackingYearStartMonth)
+
 	return model.GetSettingsResponse{
 		LinkedAccounts:      linkedAccounts,
 		ThemePreferences:    themePrefs,
 		SchedulePreferences: schedulePrefs,
+		CalendarPreferences: calendarPrefs,
 	}, nil
 }
 
@@ -61,4 +69,10 @@ func (i *Service) UpdateThemePreferences(req model.UpdateThemePreferencesRequest
 func (i *Service) UpdateSchedulePreferences(req model.UpdateSchedulePreferencesRequest) (model.UpdateSchedulePreferencesResponse, error) {
 	err := i.db.SaveSchedulePreferences(req.Meta.UserID, req.Data)
 	return model.UpdateSchedulePreferencesResponse{}, err
+}
+
+func (i *Service) UpdateCalendarPreferences(req model.UpdateCalendarPreferencesRequest) (model.UpdateCalendarPreferencesResponse, error) {
+	req.Data.TrackingYearStartMonth = util.NormaliseStartMonth(req.Data.TrackingYearStartMonth)
+	err := i.db.SaveCalendarPreferences(req.Meta.UserID, req.Data)
+	return model.UpdateCalendarPreferencesResponse{}, err
 }

--- a/internal/implementation/v1/state.go
+++ b/internal/implementation/v1/state.go
@@ -4,8 +4,19 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/baely/officetracker/internal/util"
 	"github.com/baely/officetracker/pkg/model"
 )
+
+// trackingStartMonth returns the user's configured tracking-year start month (1-12),
+// falling back to the default when unset.
+func (i *Service) trackingStartMonth(userID int) (int, error) {
+	prefs, err := i.db.GetCalendarPreferences(userID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get calendar preferences: %w", err)
+	}
+	return util.NormaliseStartMonth(prefs.TrackingYearStartMonth), nil
+}
 
 func (i *Service) GetDay(req model.GetDayRequest) (model.GetDayResponse, error) {
 	state, err := i.db.GetDay(req.Meta.UserID, req.Meta.Day, req.Meta.Month, req.Meta.Year)
@@ -52,7 +63,12 @@ func (i *Service) PutMonth(req model.PutMonthRequest) (model.PutMonthResponse, e
 }
 
 func (i *Service) GetYear(req model.GetYearRequest) (model.GetYearResponse, error) {
-	state, err := i.db.GetYear(req.Meta.UserID, req.Meta.Year)
+	startMonth, err := i.trackingStartMonth(req.Meta.UserID)
+	if err != nil {
+		return model.GetYearResponse{}, err
+	}
+
+	state, err := i.db.GetYear(req.Meta.UserID, req.Meta.Year, startMonth)
 	if err != nil {
 		err = fmt.Errorf("failed to get year: %w", err)
 		return model.GetYearResponse{}, err
@@ -66,7 +82,7 @@ func (i *Service) GetYear(req model.GetYearRequest) (model.GetYearResponse, erro
 	}
 
 	// Merge schedule preferences with actual state
-	mergedState := i.mergeScheduleWithYear(state, schedulePrefs, req.Meta.Year)
+	mergedState := i.mergeScheduleWithYear(state, schedulePrefs, req.Meta.Year, startMonth)
 
 	return model.GetYearResponse{
 		Data: mergedState,
@@ -96,7 +112,12 @@ func (i *Service) PutNote(req model.PutNoteRequest) (model.PutNoteResponse, erro
 }
 
 func (i *Service) GetNotes(req model.GetNotesRequest) (model.GetNotesResponse, error) {
-	notes, err := i.db.GetNotes(req.Meta.UserID, req.Meta.Year)
+	startMonth, err := i.trackingStartMonth(req.Meta.UserID)
+	if err != nil {
+		return model.GetNotesResponse{}, err
+	}
+
+	notes, err := i.db.GetNotes(req.Meta.UserID, req.Meta.Year, startMonth)
 	if err != nil {
 		err = fmt.Errorf("failed to get notes: %w", err)
 		return model.GetNotesResponse{}, err
@@ -108,7 +129,10 @@ func (i *Service) GetNotes(req model.GetNotesRequest) (model.GetNotesResponse, e
 }
 
 // mergeScheduleWithYear merges schedule preferences with actual state data for a year
-func (i *Service) mergeScheduleWithYear(yearState model.YearState, schedulePrefs model.SchedulePreferences, year int) model.YearState {
+func (i *Service) mergeScheduleWithYear(yearState model.YearState, schedulePrefs model.SchedulePreferences, year int, startMonth int) model.YearState {
+	startMonth = util.NormaliseStartMonth(startMonth)
+	firstYear, secondYear := util.TrackingYearCalendarYears(year, startMonth)
+
 	// Create a map for day of week to schedule state
 	dayOfWeekToState := map[time.Weekday]model.State{
 		time.Sunday:    schedulePrefs.Sunday,
@@ -122,12 +146,12 @@ func (i *Service) mergeScheduleWithYear(yearState model.YearState, schedulePrefs
 
 	// Process each month
 	for month := 1; month <= 12; month++ {
-		// Determine which year this month belongs to (academic year logic)
+		// Determine which calendar year this month belongs to within the tracking year
 		var monthYear int
-		if month <= 9 {
-			monthYear = year
+		if month >= startMonth {
+			monthYear = firstYear
 		} else {
-			monthYear = year - 1
+			monthYear = secondYear
 		}
 
 		// Initialize month if it doesn't exist

--- a/internal/report/pdf.go
+++ b/internal/report/pdf.go
@@ -96,8 +96,11 @@ func (p *PDF) addCoverPage() {
 		nameStr = p.name + " - "
 	}
 
+	// p.end is exclusive (first day after the period); the year of the last day
+	// is the tracking-year label.
+	trackingYear := p.end.AddDate(0, 0, -1).Year()
 	p.SetFont("Arial", "I", 24)
-	p.Cell(40, 10, fmt.Sprintf("%sBank Financial Year %d", nameStr, p.end.Year()))
+	p.Cell(40, 10, fmt.Sprintf("%sTracking Year %d", nameStr, trackingYear))
 	p.Ln(30)
 
 	p.addSummaryTable()

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -59,6 +59,7 @@ func settingsRouter(service *v1.Service) func(router chi.Router) {
 		r.With(middlewares...).Method(http.MethodGet, "/", wrap(service.GetSettings))
 		r.With(middlewares...).Method(http.MethodPut, "/theme", wrap(service.UpdateThemePreferences))
 		r.With(middlewares...).Method(http.MethodPut, "/schedule", wrap(service.UpdateSchedulePreferences))
+		r.With(middlewares...).Method(http.MethodPut, "/calendar", wrap(service.UpdateCalendarPreferences))
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/baely/officetracker/internal/embed"
 	v1 "github.com/baely/officetracker/internal/implementation/v1"
 	"github.com/baely/officetracker/internal/report"
+	"github.com/baely/officetracker/internal/util"
 	"github.com/baely/officetracker/pkg/model"
 )
 
@@ -167,9 +168,16 @@ func (s *Server) handleForm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if month > 9 {
-		year++
+	calendarPrefs, err := s.db.GetCalendarPreferences(userID)
+	if err != nil {
+		err = fmt.Errorf("failed to get calendar preferences: %w", err)
+		errorPage(w, r, err, internalErrorMsg, http.StatusInternalServerError)
+		return
 	}
+	startMonth := util.NormaliseStartMonth(calendarPrefs.TrackingYearStartMonth)
+
+	// Translate the displayed calendar month/year into its tracking-year label.
+	year = util.TrackingYear(month, year, startMonth)
 
 	yearlyData, err := s.v1.GetYear(model.GetYearRequest{
 		Meta: model.GetYearRequestMeta{
@@ -210,8 +218,9 @@ func (s *Server) handleForm(w http.ResponseWriter, r *http.Request) {
 	yearlyNotesStr := string(yearlyNotesByte)
 
 	serveForm(w, r, formPage{
-		YearlyState: template.JS(yearlyDataStr),
-		YearlyNotes: template.JS(yearlyNotesStr),
+		YearlyState:        template.JS(yearlyDataStr),
+		YearlyNotes:        template.JS(yearlyNotesStr),
+		TrackingStartMonth: startMonth,
 	})
 }
 
@@ -278,6 +287,7 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 		Auth0AuthURL:        authURL,
 		ThemePreferences:    settings.ThemePreferences,
 		SchedulePreferences: settings.SchedulePreferences,
+		CalendarPreferences: settings.CalendarPreferences,
 	})
 }
 

--- a/internal/server/templates.go
+++ b/internal/server/templates.go
@@ -18,8 +18,9 @@ type basePage struct {
 
 type formPage struct {
 	basePage
-	YearlyState template.JS
-	YearlyNotes template.JS
+	YearlyState        template.JS
+	YearlyNotes        template.JS
+	TrackingStartMonth int
 }
 
 func serveForm(w http.ResponseWriter, r *http.Request, page formPage) {
@@ -61,6 +62,7 @@ type settingsPage struct {
 	Auth0AuthURL        string
 	ThemePreferences    model.ThemePreferences
 	SchedulePreferences model.SchedulePreferences
+	CalendarPreferences model.CalendarPreferences
 }
 
 func serveSettings(w http.ResponseWriter, r *http.Request, page settingsPage) {

--- a/internal/server/templates_tracking_test.go
+++ b/internal/server/templates_tracking_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/baely/officetracker/internal/embed"
+	"github.com/baely/officetracker/pkg/model"
+)
+
+// TestFormTemplateRendersTrackingStartMonth ensures the form template parses and
+// the injected tracking start month is rendered into the page (form.js consumes it).
+func TestFormTemplateRendersTrackingStartMonth(t *testing.T) {
+	var buf strings.Builder
+	err := embed.Form.Execute(&buf, formPage{
+		YearlyState:        "{}",
+		YearlyNotes:        "{}",
+		TrackingStartMonth: 7,
+	})
+	if err != nil {
+		t.Fatalf("failed to execute form template: %v", err)
+	}
+	// html/template's JS escaper pads injected values with spaces; collapse
+	// whitespace before asserting.
+	normalised := strings.Join(strings.Fields(buf.String()), " ")
+	if !strings.Contains(normalised, "trackingStartMonth = 7 || 10") {
+		t.Fatalf("expected rendered form to inject trackingStartMonth = 7")
+	}
+}
+
+// TestSettingsTemplateRendersCalendarPreference ensures the settings template
+// parses and renders the calendar preference selector value.
+func TestSettingsTemplateRendersCalendarPreference(t *testing.T) {
+	err := embed.Settings.Execute(io.Discard, settingsPage{
+		CalendarPreferences: model.CalendarPreferences{TrackingYearStartMonth: 4},
+	})
+	if err != nil {
+		t.Fatalf("failed to execute settings template: %v", err)
+	}
+}

--- a/internal/util/trackingyear.go
+++ b/internal/util/trackingyear.go
@@ -1,0 +1,58 @@
+package util
+
+import "time"
+
+// Tracking-year helpers.
+//
+// Entries are stored against their raw calendar (year, month). A "tracking year"
+// is a presentation grouping of 12 consecutive months starting at a configurable
+// start month (1-12, e.g. 10 = October). It lets users align attendance reporting
+// to whatever 12-month cycle their workplace uses.
+//
+// A tracking year is labelled by the calendar year in which it *ends*
+// (e.g. an October start means the period Oct 2023 - Sep 2024 is labelled 2024).
+// When the start month is January the tracking year coincides with the calendar
+// year, so it is labelled by that same year.
+
+// NormaliseStartMonth clamps an arbitrary value to a valid month (1-12),
+// falling back to the October default when out of range.
+func NormaliseStartMonth(startMonth int) int {
+	if startMonth < 1 || startMonth > 12 {
+		return 10
+	}
+	return startMonth
+}
+
+// TrackingYear returns the tracking-year label that a given calendar month
+// (1-12) in calendar year cy belongs to.
+func TrackingYear(month, cy, startMonth int) int {
+	startMonth = NormaliseStartMonth(startMonth)
+	if startMonth == 1 {
+		return cy
+	}
+	if month >= startMonth {
+		return cy + 1
+	}
+	return cy
+}
+
+// TrackingYearCalendarYears returns the two calendar years spanned by the
+// tracking year labelled ty: months >= startMonth belong to firstYear, months <
+// startMonth belong to secondYear. For a January start both are equal to ty.
+func TrackingYearCalendarYears(ty, startMonth int) (firstYear, secondYear int) {
+	startMonth = NormaliseStartMonth(startMonth)
+	if startMonth == 1 {
+		return ty, ty
+	}
+	return ty - 1, ty
+}
+
+// TrackingYearRange returns the half-open [start, end) date range covering the
+// tracking year labelled ty.
+func TrackingYearRange(ty, startMonth int) (start, end time.Time) {
+	startMonth = NormaliseStartMonth(startMonth)
+	firstYear, _ := TrackingYearCalendarYears(ty, startMonth)
+	start = time.Date(firstYear, time.Month(startMonth), 1, 0, 0, 0, 0, time.Local)
+	end = start.AddDate(1, 0, 0)
+	return start, end
+}

--- a/internal/util/trackingyear_test.go
+++ b/internal/util/trackingyear_test.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTrackingYear(t *testing.T) {
+	cases := []struct {
+		name       string
+		month, cy  int
+		startMonth int
+		want       int
+	}{
+		// October start (default, must match original behaviour).
+		{"oct: sep stays", 9, 2024, 10, 2024},
+		{"oct: oct rolls", 10, 2023, 10, 2024},
+		{"oct: dec rolls", 12, 2023, 10, 2024},
+		{"oct: jan stays", 1, 2024, 10, 2024},
+		// January start == calendar year.
+		{"jan: jan", 1, 2024, 1, 2024},
+		{"jan: dec", 12, 2024, 1, 2024},
+		// July start.
+		{"jul: jun stays", 6, 2024, 7, 2024},
+		{"jul: jul rolls", 7, 2023, 7, 2024},
+		// Out of range falls back to October default.
+		{"bad: treated as oct", 10, 2023, 0, 2024},
+	}
+	for _, c := range cases {
+		if got := TrackingYear(c.month, c.cy, c.startMonth); got != c.want {
+			t.Errorf("%s: TrackingYear(%d,%d,%d)=%d want %d", c.name, c.month, c.cy, c.startMonth, got, c.want)
+		}
+	}
+}
+
+func TestTrackingYearCalendarYears(t *testing.T) {
+	cases := []struct {
+		ty, startMonth        int
+		wantFirst, wantSecond int
+	}{
+		{2024, 10, 2023, 2024},
+		{2024, 1, 2024, 2024},
+		{2024, 7, 2023, 2024},
+	}
+	for _, c := range cases {
+		first, second := TrackingYearCalendarYears(c.ty, c.startMonth)
+		if first != c.wantFirst || second != c.wantSecond {
+			t.Errorf("TrackingYearCalendarYears(%d,%d)=(%d,%d) want (%d,%d)", c.ty, c.startMonth, first, second, c.wantFirst, c.wantSecond)
+		}
+	}
+}
+
+func TestTrackingYearRange(t *testing.T) {
+	cases := []struct {
+		ty, startMonth int
+		wantStart      time.Time
+		wantEnd        time.Time
+	}{
+		{2024, 10, time.Date(2023, time.October, 1, 0, 0, 0, 0, time.Local), time.Date(2024, time.October, 1, 0, 0, 0, 0, time.Local)},
+		{2024, 1, time.Date(2024, time.January, 1, 0, 0, 0, 0, time.Local), time.Date(2025, time.January, 1, 0, 0, 0, 0, time.Local)},
+		{2024, 7, time.Date(2023, time.July, 1, 0, 0, 0, 0, time.Local), time.Date(2024, time.July, 1, 0, 0, 0, 0, time.Local)},
+	}
+	for _, c := range cases {
+		start, end := TrackingYearRange(c.ty, c.startMonth)
+		if !start.Equal(c.wantStart) || !end.Equal(c.wantEnd) {
+			t.Errorf("TrackingYearRange(%d,%d)=(%v,%v) want (%v,%v)", c.ty, c.startMonth, start, end, c.wantStart, c.wantEnd)
+		}
+	}
+}

--- a/pkg/model/common.go
+++ b/pkg/model/common.go
@@ -28,3 +28,7 @@ type YearState struct {
 type Note struct {
 	Note string `json:"note"`
 }
+
+// DefaultTrackingYearStartMonth is the month (1-12) a tracking year starts on by
+// default. October matches the original hardcoded behaviour.
+const DefaultTrackingYearStartMonth = 10

--- a/pkg/model/http.go
+++ b/pkg/model/http.go
@@ -163,6 +163,13 @@ type SchedulePreferences struct {
 	Sunday    State `json:"sunday"`
 }
 
+// CalendarPreferences holds settings that control how the reporting/tracking year
+// is laid out for a user.
+type CalendarPreferences struct {
+	// TrackingYearStartMonth is the month (1-12) the tracking year starts on.
+	TrackingYearStartMonth int `json:"tracking_year_start_month"`
+}
+
 type LinkedAccount struct {
 	Provider        string `json:"provider"`
 	ProviderDisplay string `json:"provider_display"`
@@ -173,6 +180,7 @@ type GetSettingsResponse struct {
 	LinkedAccounts      []LinkedAccount     `json:"linked_accounts"`
 	ThemePreferences    ThemePreferences    `json:"theme_preferences"`
 	SchedulePreferences SchedulePreferences `json:"schedule_preferences"`
+	CalendarPreferences CalendarPreferences `json:"calendar_preferences"`
 }
 
 type UpdateThemePreferencesRequest struct {
@@ -196,6 +204,17 @@ type UpdateSchedulePreferencesRequestMeta struct {
 }
 
 type UpdateSchedulePreferencesResponse struct{}
+
+type UpdateCalendarPreferencesRequest struct {
+	Meta UpdateCalendarPreferencesRequestMeta `meta:"meta" json:"-"`
+	Data CalendarPreferences                  `json:"data"`
+}
+
+type UpdateCalendarPreferencesRequestMeta struct {
+	UserID int `meta:"user_id"`
+}
+
+type UpdateCalendarPreferencesResponse struct{}
 
 // Token management models
 type PostSecretRequest struct {


### PR DESCRIPTION
## Summary
The attendance reporting year was hardcoded to **October** throughout the DB queries, API, reports, and calendar UI. This makes it a per-user **"tracking year"** preference stored in `user_preferences`, configurable from the settings page, **defaulting to October** so existing behaviour is unchanged.

(Named "tracking year" rather than "fiscal/financial year" since this is an office-attendance app, not a finance app.)

## What changed
- **Shared helpers** — new `internal/util/trackingyear.go` (`TrackingYear`, `TrackingYearCalendarYears`, `TrackingYearRange`, `NormaliseStartMonth`). October behaves bit-for-bit as before; January collapses to a plain calendar year; any month works.
- **Storage** — `tracking_year_start_month` column on `user_preferences` (Postgres migration `009` + sqlite auto-ALTER), default `10`. New `Get/SaveCalendarPreferences` DB methods; `CalendarPreferences` folded into the settings response.
- **DB queries** — `GetYear`/`GetNotes` no longer hardcode `month>9 … year-1`; they take a `startMonth` and derive the spanned calendar years.
- **API/impl** — `GetYear`, `GetNotes`, PDF/CSV reports, and `mergeScheduleWithYear` resolve the user's start month; new `PUT /api/v1/settings/calendar`; PDF cover relabelled "Tracking Year N" (computed from the period's last day, correct for any start month).
- **UI** — `form.js`'s hardcoded October boundaries replaced with helpers driven by an injected `trackingStartMonth`; settings page gains a **"Tracking Year"** month dropdown that loads/saves the preference.

## Testing
- `go build ./...`, `-tags standalone`, `-tags integrated` — all clean; `go vet` clean.
- `go test ./internal/util/... ./internal/server/...` — tracking-year unit tests + template render/exec tests pass.
- Live round-trip (standalone): a 12 Sep 2024 office day sits in tracking-year 2024 under October-start, shifts to 2025 under July-start; CSV for July-2025 spans 2024-07-01→2025-06-30 and includes the entry; PDF generates.
- Full Docker stack (Postgres+Redis+OIDC mock+app): migration `009-tracking-year-start.sql` applied, column `tracking_year_start_month` present (default 10), app healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)