### PR TITLE
Standardise product name to "Officetracker"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Office Tracker
+# Officetracker
 A web application designed to track compliance with Return-to-Office (RTO) mandates, featuring a user-friendly calendar interface for logging office presence and generating comprehensive summary statistics and reports for compliance assessment.
 
 ![Screenshot of web app](docs/assets/screenshot-v1.png)
@@ -80,7 +80,7 @@ Example:
 
 ## Model Context Protocol (MCP) Integration
 
-Office Tracker includes built-in MCP server support, allowing AI assistants like Claude to interact with your office tracking data. The MCP endpoint is available at `/mcp/v1/`.
+Officetracker includes built-in MCP server support, allowing AI assistants like Claude to interact with your office tracking data. The MCP endpoint is available at `/mcp/v1/`.
 
 ### Available MCP Tools
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.3
 info:
-  title: OfficeTracker API
+  title: Officetracker API
   description: API for tracking office attendance and managing user settings
   version: 1.0.0
   contact:
-    name: OfficeTracker
+    name: Officetracker
     url: https://github.com/baely/officetracker
 
 servers:

--- a/internal/embed/html/index_old.html
+++ b/internal/embed/html/index_old.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Office Tracker</title>
+    <title>Officetracker</title>
     <style>
         body {
             font-family: Arial, sans-serif;


### PR DESCRIPTION
## Summary
Unifies the product's display name to **Officetracker** everywhere it's shown to users. Previously a few surfaces used "Office Tracker" (spaced) or "OfficeTracker" (camelCase).

## Changes
- `README.md` — top-level heading and the MCP integration sentence
- `docs/openapi.yaml` — API `title` and contact `name`
- `internal/embed/html/index_old.html` — page `<title>`

## Intentionally left unchanged
These are technical identifiers, not the user-facing product name — renaming them would break builds/deploys:
- Lowercase `officetracker` in Go import paths (`github.com/baely/officetracker/...`), package names, the domain, env vars, and Docker service names
- `mcp__office-tracker__*` tool IDs in local settings

## Verification
- `go build ./...` passes
- Repo-wide grep confirms no remaining "Office Tracker" / "OfficeTracker" display references

🤖 Generated with [Claude Code](https://claude.com/claude-code)