### PR TITLE
Force a fresh login and simplify the mobile auth flow

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -11,7 +11,7 @@ import SettingsScreen from './src/screens/SettingsScreen';
 import { clearConnection, Connection, loadConnection } from './src/storage';
 import { colors } from './src/theme';
 
-type Screen = 'loading' | 'login' | 'relogin' | 'calendar' | 'settings';
+type Screen = 'loading' | 'login' | 'calendar' | 'settings';
 
 export default function App() {
   const [screen, setScreen] = useState<Screen>('loading');
@@ -56,15 +56,8 @@ export default function App() {
     case 'loading':
       break;
     case 'login':
-    case 'relogin':
       body = (
-        <LoginScreen
-          initialBaseUrl={conn?.baseUrl}
-          onConnected={onConnected}
-          onCancel={
-            screen === 'relogin' ? () => setScreen('settings') : undefined
-          }
-        />
+        <LoginScreen initialBaseUrl={conn?.baseUrl} onConnected={onConnected} />
       );
       break;
     case 'calendar':
@@ -81,7 +74,6 @@ export default function App() {
         <SettingsScreen
           conn={conn}
           onClose={() => setScreen('calendar')}
-          onSignInAgain={() => setScreen('relogin')}
           onUnauthorized={handleUnauthorized}
           onDisconnect={() => {
             setConn(null);

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -46,8 +46,16 @@ export default function LoginScreen({
     setBusy(true);
     try {
       const credentials = await authorize(
-        { scope: 'openid profile email' },
-        { customScheme: AUTH0_SCHEME },
+        // Always show a fresh login screen instead of silently reusing a cached
+        // Auth0 session. prompt=login asks the server to re-prompt, and
+        // ephemeralSession runs the iOS web flow in a private session that
+        // doesn't share Safari's cookies — so no SSO session lingers after a
+        // sign-out and signing back in actually asks for credentials.
+        {
+          scope: 'openid profile email',
+          additionalParameters: { prompt: 'login' },
+        },
+        { customScheme: AUTH0_SCHEME, ephemeralSession: true },
       );
       if (!credentials?.idToken) {
         // User cancelled the Auth0 prompt.

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -23,7 +23,6 @@ import { colors, radius, spacing } from '../theme';
 interface Props {
   conn: Connection;
   onClose: () => void;
-  onSignInAgain: () => void;
   onUnauthorized: () => void;
   onDisconnect: () => void;
 }
@@ -36,7 +35,6 @@ function formatDate(iso: string): string {
 export default function SettingsScreen({
   conn,
   onClose,
-  onSignInAgain,
   onUnauthorized,
   onDisconnect,
 }: Props) {
@@ -358,16 +356,6 @@ export default function SettingsScreen({
               </Pressable>
             </View>
           )}
-
-          {/* Connection */}
-          <Text style={styles.sectionLabel}>Connection</Text>
-          <View style={styles.card}>
-            <Text style={styles.fieldLabel}>Server</Text>
-            <Text style={styles.fieldValue}>{conn.baseUrl}</Text>
-          </View>
-          <Pressable style={styles.button} onPress={onSignInAgain}>
-            <Text style={styles.buttonText}>Sign in again</Text>
-          </Pressable>
 
           <Pressable style={[styles.button, styles.danger]} onPress={signOut}>
             <Text style={[styles.buttonText, styles.dangerText]}>Sign out</Text>


### PR DESCRIPTION
## What
Behavioural follow-up to #228, **stacked on it** (base branch `mobile-web-redesign`). Fixes the mobile auth/session flow.

## Why
On iOS the Auth0 login runs in a web session that shares Safari's cookies, so signing out and back in silently re-authenticated against the cached SSO session — you could never actually switch account.

## Changes
- `LoginScreen`: authorize with `ephemeralSession: true` (private web session, no shared cookies) and `prompt=login`, so signing in always shows the Auth0 login screen.
- Remove "Sign in again" and the server field from Settings; delete the now-dead relogin screen from `App.tsx`.
- Switching server/account is now: **Sign out → login screen → "Use a different server"**.

## Testing
- `tsc --noEmit` passes.
- Run on the iOS simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
