### PR TITLE
Mobile: web redesign, geofencing & read-only support

### DIFF
--- a/.github/workflows/mobile-eas-build.yaml
+++ b/.github/workflows/mobile-eas-build.yaml
@@ -1,11 +1,15 @@
 name: EAS Build
 
-# Manually triggers a cloud build of the mobile app on Expo Application Services.
-# The build runs on EAS infrastructure (not the GitHub runner); --no-wait queues
-# it and returns, so check progress at https://expo.dev. Requires an EXPO_TOKEN
-# repo secret (an Expo access token for the baelys-team account).
+# Builds the mobile app on Expo Application Services (EAS). Runs on every push
+# to mobile-dev (ios + preview by default), and can be triggered manually with
+# a chosen platform/profile and optional store submit. The build runs on EAS
+# infrastructure (not the GitHub runner); --no-wait queues it and returns, so
+# check progress at https://expo.dev. Requires an EXPO_TOKEN repo secret (an
+# Expo access token for the baelys-team account).
 
 on:
+  push:
+    branches: [mobile-dev]
   workflow_dispatch:
     inputs:
       platform:
@@ -53,8 +57,8 @@ jobs:
       - name: Build on EAS
         run: |
           eas build \
-            --platform ${{ inputs.platform }} \
-            --profile ${{ inputs.profile }} \
+            --platform ${{ inputs.platform || 'ios' }} \
+            --profile ${{ inputs.profile || 'preview' }} \
             --non-interactive \
             --no-wait \
             ${{ inputs.submit && '--auto-submit' || '' }}

--- a/.github/workflows/mobile-eas-build.yaml
+++ b/.github/workflows/mobile-eas-build.yaml
@@ -1,0 +1,60 @@
+name: EAS Build
+
+# Manually triggers a cloud build of the mobile app on Expo Application Services.
+# The build runs on EAS infrastructure (not the GitHub runner); --no-wait queues
+# it and returns, so check progress at https://expo.dev. Requires an EXPO_TOKEN
+# repo secret (an Expo access token for the baelys-team account).
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "Platform to build"
+        type: choice
+        options: [ios, android, all]
+        default: ios
+      profile:
+        description: "EAS build profile (see mobile/eas.json)"
+        type: choice
+        options: [development, preview, production]
+        default: production
+      submit:
+        description: "Submit to the store once the build finishes"
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    name: EAS Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build on EAS
+        run: |
+          eas build \
+            --platform ${{ inputs.platform }} \
+            --profile ${{ inputs.profile }} \
+            --non-interactive \
+            --no-wait \
+            ${{ inputs.submit && '--auto-submit' || '' }}

--- a/.github/workflows/mobile-eas-build.yaml
+++ b/.github/workflows/mobile-eas-build.yaml
@@ -1,12 +1,16 @@
 name: EAS Build
 
 # Builds the mobile app on Expo Application Services (EAS). Every push to
-# mobile-dev builds the ios production profile and auto-submits it to App Store
-# Connect (TestFlight). Can also be triggered manually with a chosen
-# platform/profile and an optional submit toggle. The build runs on EAS
-# infrastructure (not the GitHub runner); --no-wait queues it and returns, so
-# check progress at https://expo.dev. Requires an EXPO_TOKEN repo secret (an
-# Expo access token for the baelys-team account).
+# mobile-dev builds the production profile for both platforms and auto-submits
+# them: iOS to App Store Connect (TestFlight) and Android to the Play Store
+# internal track (eas.json -> submit.production.android.track). Can also be
+# triggered manually with a chosen platform/profile and an optional submit
+# toggle. The build runs on EAS infrastructure (not the GitHub runner);
+# --no-wait queues it and returns, so check progress at https://expo.dev.
+# Requires an EXPO_TOKEN repo secret (an Expo access token for the baelys-team
+# account). Store submission uses credentials saved in EAS: the App Store
+# Connect API key and the Google Play service account key (run `eas credentials`
+# once per platform to upload them).
 
 on:
   push:
@@ -58,7 +62,7 @@ jobs:
       - name: Build on EAS
         run: |
           eas build \
-            --platform ${{ inputs.platform || 'ios' }} \
+            --platform ${{ inputs.platform || 'all' }} \
             --profile ${{ inputs.profile || 'production' }} \
             --non-interactive \
             --no-wait \

--- a/.github/workflows/mobile-eas-build.yaml
+++ b/.github/workflows/mobile-eas-build.yaml
@@ -1,20 +1,22 @@
 name: EAS Build
 
-# Builds the mobile app on Expo Application Services (EAS). Every push to
-# mobile-dev builds the production profile for both platforms and auto-submits
-# them: iOS to App Store Connect (TestFlight) and Android to the Play Store
-# internal track (eas.json -> submit.production.android.track). Can also be
-# triggered manually with a chosen platform/profile and an optional submit
-# toggle. The build runs on EAS infrastructure (not the GitHub runner);
-# --no-wait queues it and returns, so check progress at https://expo.dev.
-# Requires an EXPO_TOKEN repo secret (an Expo access token for the baelys-team
-# account). Store submission uses credentials saved in EAS: the App Store
-# Connect API key and the Google Play service account key (run `eas credentials`
-# once per platform to upload them).
+# Builds the mobile app on Expo Application Services (EAS). Runs only when a new
+# version tag (v*) is pushed or when triggered manually — never on ordinary
+# commits. A tag push builds the production profile for both platforms and
+# auto-submits them: iOS to App Store Connect (TestFlight) and Android to the
+# Play Store internal track (eas.json -> submit.production.android.track). Manual
+# dispatch lets you pick the platform/profile and whether to submit. The build
+# runs on EAS infrastructure (not the GitHub runner); --no-wait queues it and
+# returns, so check progress at https://expo.dev. Requires an EXPO_TOKEN repo
+# secret (an Expo access token for the baelys-team account). Store submission
+# uses credentials saved in EAS: the App Store Connect API key and the Google
+# Play service account key (run `eas credentials` once per platform to upload
+# them).
 
 on:
   push:
-    branches: [mobile-dev]
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       platform:

--- a/.github/workflows/mobile-eas-build.yaml
+++ b/.github/workflows/mobile-eas-build.yaml
@@ -1,8 +1,9 @@
 name: EAS Build
 
-# Builds the mobile app on Expo Application Services (EAS). Runs on every push
-# to mobile-dev (ios + preview by default), and can be triggered manually with
-# a chosen platform/profile and optional store submit. The build runs on EAS
+# Builds the mobile app on Expo Application Services (EAS). Every push to
+# mobile-dev builds the ios production profile and auto-submits it to App Store
+# Connect (TestFlight). Can also be triggered manually with a chosen
+# platform/profile and an optional submit toggle. The build runs on EAS
 # infrastructure (not the GitHub runner); --no-wait queues it and returns, so
 # check progress at https://expo.dev. Requires an EXPO_TOKEN repo secret (an
 # Expo access token for the baelys-team account).
@@ -58,7 +59,7 @@ jobs:
         run: |
           eas build \
             --platform ${{ inputs.platform || 'ios' }} \
-            --profile ${{ inputs.profile || 'preview' }} \
+            --profile ${{ inputs.profile || 'production' }} \
             --non-interactive \
             --no-wait \
-            ${{ inputs.submit && '--auto-submit' || '' }}
+            ${{ (inputs.submit || github.event_name == 'push') && '--auto-submit' || '' }}

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -11,7 +11,7 @@ import SettingsScreen from './src/screens/SettingsScreen';
 import { clearConnection, Connection, loadConnection } from './src/storage';
 import { colors } from './src/theme';
 
-type Screen = 'loading' | 'login' | 'relogin' | 'calendar' | 'settings';
+type Screen = 'loading' | 'login' | 'calendar' | 'settings';
 
 export default function App() {
   const [screen, setScreen] = useState<Screen>('loading');
@@ -56,15 +56,8 @@ export default function App() {
     case 'loading':
       break;
     case 'login':
-    case 'relogin':
       body = (
-        <LoginScreen
-          initialBaseUrl={conn?.baseUrl}
-          onConnected={onConnected}
-          onCancel={
-            screen === 'relogin' ? () => setScreen('settings') : undefined
-          }
-        />
+        <LoginScreen initialBaseUrl={conn?.baseUrl} onConnected={onConnected} />
       );
       break;
     case 'calendar':
@@ -81,7 +74,6 @@ export default function App() {
         <SettingsScreen
           conn={conn}
           onClose={() => setScreen('calendar')}
-          onSignInAgain={() => setScreen('relogin')}
           onUnauthorized={handleUnauthorized}
           onDisconnect={() => {
             setConn(null);

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,10 +1,14 @@
 import { Calistoga_400Regular, useFonts } from '@expo-google-fonts/calistoga';
 import { StatusBar } from 'expo-status-bar';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, Alert, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, Alert, AppState, StyleSheet, View } from 'react-native';
 import { Auth0Provider } from 'react-native-auth0';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { AUTH0_CLIENT_ID, AUTH0_DOMAIN } from './src/config';
+// Importing this registers the background geofence task (TaskManager.defineTask),
+// which must happen at module load so it's available when iOS/Android relaunch
+// the app for a location event.
+import { checkProximityNow, syncWorkGeofence } from './src/location';
 import CalendarScreen from './src/screens/CalendarScreen';
 import LoginScreen from './src/screens/LoginScreen';
 import SettingsScreen from './src/screens/SettingsScreen';
@@ -25,6 +29,19 @@ export default function App() {
       setConn(c);
       setScreen(c ? 'calendar' : 'login');
     });
+  }, []);
+
+  // Resume work-location tracking after a restart, and catch the case where the
+  // app opens while already at work (a geofence only fires on a crossing). Both
+  // only read existing permissions — they never prompt — so they're safe to run
+  // every launch. The work logic no-ops when no location/connection is stored.
+  useEffect(() => {
+    syncWorkGeofence();
+    checkProximityNow();
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') checkProximityNow();
+    });
+    return () => sub.remove();
   }, []);
 
   // On a rejected token (401/403): drop the session and return to login.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -48,8 +48,32 @@ calls. The token shows up on the server's Developer page as
 
 By default it connects to `https://officetracker.com.au`. Tap **Use a different
 server** on the login screen to point at another instance (e.g.
-`https://beta.officetracker.com.au`) — note it still authenticates against the
-same Auth0 tenant.
+`https://beta.officetracker.com.au`) — for an Auth0-backed instance it still
+authenticates against the same Auth0 tenant.
+
+### Server capabilities (`/api/v1/meta`)
+
+When connecting, the app probes `GET /api/v1/meta` to learn how to talk to the
+server. The response is JSON:
+
+```json
+{ "auth": "auth0", "read_only": false }
+```
+
+- `auth`: `"auth0"` (default) means do the Auth0 sign-in + `POST /auth/native`
+  token exchange described above. `"none"` means the server is **anonymous** —
+  the app skips Auth0 entirely and connects with no token (the **Sign in**
+  button becomes **Continue**).
+- `read_only`: when `true`, the app locks the whole UI to **read-only** —
+  attendance days and notes can be browsed but not edited, the work-location
+  prompt is hidden, and the account / work-location / developer-token sections of
+  Settings are hidden (sign-out becomes **Disconnect**). Mutating requests are
+  also refused client-side as a safeguard.
+
+Servers that don't implement `/api/v1/meta` (HTTP 404, or unreachable) fall back
+to the historical default — `auth0` and writable — so existing instances keep
+working unchanged. A public demo instance ("demotracker") would serve
+`{ "auth": "none", "read_only": true }`.
 
 ## Auth0 configuration
 

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -16,6 +16,9 @@
         "ITSAppUsesNonExemptEncryption": false
       }
     },
+    "android": {
+      "package": "com.baely.officetracker"
+    },
     "plugins": [
       [
         "react-native-auth0",

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -11,7 +11,10 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.baely.officetracker"
+      "bundleIdentifier": "com.baely.officetracker",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "plugins": [
       [

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -13,11 +13,21 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.baely.officetracker",
       "infoPlist": {
-        "ITSAppUsesNonExemptEncryption": false
+        "ITSAppUsesNonExemptEncryption": false,
+        "NSLocationWhenInUseUsageDescription": "Officetracker uses your location to detect when you arrive at work so it can mark the day as an office day.",
+        "NSLocationAlwaysAndWhenInUseUsageDescription": "Officetracker checks for arrival at your work location in the background so it can automatically mark office days, even when the app is closed.",
+        "UIBackgroundModes": ["location"]
       }
     },
     "android": {
-      "package": "com.baely.officetracker"
+      "package": "com.baely.officetracker",
+      "permissions": [
+        "ACCESS_COARSE_LOCATION",
+        "ACCESS_FINE_LOCATION",
+        "ACCESS_BACKGROUND_LOCATION",
+        "FOREGROUND_SERVICE",
+        "FOREGROUND_SERVICE_LOCATION"
+      ]
     },
     "plugins": [
       [
@@ -27,7 +37,16 @@
           "customScheme": "officetracker"
         }
       ],
-      "expo-font"
+      "expo-font",
+      [
+        "expo-location",
+        {
+          "locationAlwaysAndWhenInUsePermission": "Officetracker checks for arrival at your work location in the background so it can automatically mark office days, even when the app is closed.",
+          "locationWhenInUsePermission": "Officetracker uses your location to detect when you arrive at work so it can mark the day as an office day.",
+          "isAndroidBackgroundLocationEnabled": true,
+          "isAndroidForegroundServiceEnabled": true
+        }
+      ]
     ],
     "extra": {
       "eas": {

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -16,6 +16,8 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ascAppId": "6780482250"
+    }
   }
 }

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -19,6 +19,9 @@
     "production": {
       "ios": {
         "ascAppId": "6780482250"
+      },
+      "android": {
+        "track": "internal"
       }
     }
   }

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -17,7 +17,9 @@
   },
   "submit": {
     "production": {
-      "ascAppId": "6780482250"
+      "ios": {
+        "ascAppId": "6780482250"
+      }
     }
   }
 }

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -14,11 +14,15 @@
         "expo": "~56.0.11",
         "expo-dev-client": "~56.0.20",
         "expo-font": "~56.0.6",
+        "expo-location": "~56.0.18",
         "expo-status-bar": "~56.0.4",
+        "expo-task-manager": "~56.0.19",
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-native-auth0": "^5.7.0",
-        "react-native-safe-area-context": "~5.7.0"
+        "react-native-maps": "1.27.2",
+        "react-native-safe-area-context": "~5.7.0",
+        "react-native-webview": "13.16.1"
       },
       "devDependencies": {
         "@types/react": "~19.2.2",
@@ -1781,6 +1785,12 @@
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2964,6 +2974,18 @@
       "integrity": "sha512-lUqyv9aIGDbYTQ5Nux2FnH2/Dz0w5uJ8Pr080eS0StXi2jr5OmuMNErpzUnpfnYOU55xKotd4AHv68PfV/ludg==",
       "license": "MIT"
     },
+    "node_modules/expo-location": {
+      "version": "56.0.18",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-56.0.18.tgz",
+      "integrity": "sha512-6xP0UwGy8a7EEHAMeigYAp3HNo3yWHAg05tVPUfwrOWepWPpFXmjsfUBUxQdkpfpjddJ9r+f4PplxZqKI0LtjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.10.1"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-manifests": {
       "version": "56.0.4",
       "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-56.0.4.tgz",
@@ -3038,6 +3060,19 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-task-manager": {
+      "version": "56.0.19",
+      "resolved": "https://registry.npmjs.org/expo-task-manager/-/expo-task-manager-56.0.19.tgz",
+      "integrity": "sha512-eDeBR8vXlOAXBck29AzPl+tv4QlJus+cgkQ0TGOBqAlgRPWPWd7ebhqrhb0KRieUZIvzlycfcxjHR/+AiEiMHA==",
+      "license": "MIT",
+      "dependencies": {
+        "unimodules-app-loader": "~56.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },
@@ -5795,6 +5830,28 @@
         }
       }
     },
+    "node_modules/react-native-maps": {
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.27.2.tgz",
+      "integrity": "sha512-VKr+xZ2RZGHHJlY6KhlafvGSmK0dq/tUu5uhfJ7K9rwN5pUdubdugzMKGDU/16lXmQSg7xbClKhRctj3Pm5F5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      },
+      "peerDependencies": {
+        "react": ">= 18.3.1",
+        "react-native": ">= 0.76.0",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.7.0.tgz",
@@ -5848,8 +5905,6 @@
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.1.tgz",
       "integrity": "sha512-If0eHhoEdOYDcHsX+xBFwHMbWBGK1BvGDQDQdVkwtSIXiq1uiqjkpWVP2uQ1as94J0CzvFE9PUNDuhiX0Z6ubw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
@@ -6710,6 +6765,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/unimodules-app-loader": {
+      "version": "56.0.1",
+      "resolved": "https://registry.npmjs.org/unimodules-app-loader/-/unimodules-app-loader-56.0.1.tgz",
+      "integrity": "sha512-Z801jeBOQMUF/ExklxT1BqhEV/oF2/Bii7PFYAj/8Sauxl7oKvZbf70peRzzAU0mG7UQ3yU/UO/EpD1JyJ2WcA==",
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -8,11 +8,15 @@
     "expo": "~56.0.11",
     "expo-dev-client": "~56.0.20",
     "expo-font": "~56.0.6",
+    "expo-location": "~56.0.18",
     "expo-status-bar": "~56.0.4",
+    "expo-task-manager": "~56.0.19",
     "react": "19.2.3",
     "react-native": "0.85.3",
     "react-native-auth0": "^5.7.0",
-    "react-native-safe-area-context": "~5.7.0"
+    "react-native-maps": "1.27.2",
+    "react-native-safe-area-context": "~5.7.0",
+    "react-native-webview": "13.16.1"
   },
   "devDependencies": {
     "@types/react": "~19.2.2",

--- a/mobile/src/api.ts
+++ b/mobile/src/api.ts
@@ -89,6 +89,39 @@ async function rawFetch(url: string, init?: RequestInit): Promise<Response> {
   }
 }
 
+// How a server expects clients to authenticate. 'none' means the server serves
+// anonymous requests with no token (e.g. a public demo instance).
+export type ServerAuth = 'auth0' | 'none';
+
+export interface ServerMeta {
+  // Authentication scheme the server expects.
+  auth: ServerAuth;
+  // When true the server rejects all writes; the app locks its UI to read-only.
+  readOnly: boolean;
+}
+
+// Probes a server's capabilities via GET /api/v1/meta. Servers that predate the
+// endpoint (or that can't be reached) fall back to the historical default —
+// Auth0 sign-in and a writable instance — so existing instances keep working.
+export async function fetchServerMeta(baseUrl: string): Promise<ServerMeta> {
+  try {
+    const res = await rawFetch(`${normaliseBase(baseUrl)}/api/v1/meta`);
+    if (!res.ok) return { auth: 'auth0', readOnly: false };
+    const body = (await res.json()) as {
+      auth?: string;
+      // Accept both the Go snake_case wire form and a camelCase fallback.
+      read_only?: boolean;
+      readOnly?: boolean;
+    };
+    return {
+      auth: body.auth === 'none' ? 'none' : 'auth0',
+      readOnly: !!(body.read_only ?? body.readOnly),
+    };
+  } catch {
+    return { auth: 'auth0', readOnly: false };
+  }
+}
+
 // Exchanges an Auth0 ID token (obtained natively via react-native-auth0) for a
 // long-lived Office Tracker API token. See the server's /auth/native handler.
 export async function exchangeNativeToken(
@@ -132,6 +165,12 @@ export class Api {
   }
 
   private async request(path: string, init?: RequestInit): Promise<Response> {
+    // Defence in depth: the UI hides writes on a read-only server, but never let
+    // a mutating request leave the device regardless of which code path calls in.
+    const method = (init?.method ?? 'GET').toUpperCase();
+    if (this.conn.readOnly && method !== 'GET') {
+      throw new ApiError('This server is read-only.', 405);
+    }
     const res = await rawFetch(this.url(path), init);
     if (res.status === 401 || res.status === 403) {
       // Token expired or revoked — trigger a sign-out.

--- a/mobile/src/api.ts
+++ b/mobile/src/api.ts
@@ -90,7 +90,7 @@ async function rawFetch(url: string, init?: RequestInit): Promise<Response> {
 }
 
 // How a server expects clients to authenticate. 'none' means the server serves
-// anonymous requests with no token (e.g. a public demo instance).
+// anonymous requests with no token (e.g. a public read-only instance).
 export type ServerAuth = 'auth0' | 'none';
 
 export interface ServerMeta {

--- a/mobile/src/components/Calendar.tsx
+++ b/mobile/src/components/Calendar.tsx
@@ -11,9 +11,11 @@ interface Props {
   month: number; // 1-12
   days: MonthDays;
   onCycle: (day: number, direction: 1 | -1) => void;
+  // Display-only: render days without responding to taps (read-only server).
+  readOnly?: boolean;
 }
 
-function Calendar({ year, month, days, onCycle }: Props) {
+function Calendar({ year, month, days, onCycle, readOnly }: Props) {
   const weeks = monthGrid(year, month);
 
   return (
@@ -39,6 +41,7 @@ function Calendar({ year, month, days, onCycle }: Props) {
               }
               onPress={() => cell.day != null && onCycle(cell.day, 1)}
               onLongPress={() => cell.day != null && onCycle(cell.day, -1)}
+              disabled={readOnly}
             />
           ))}
         </View>

--- a/mobile/src/components/Calendar.tsx
+++ b/mobile/src/components/Calendar.tsx
@@ -52,14 +52,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     marginBottom: spacing.xs,
   },
+  // Plain text per column, centred so it still lines up with the day columns.
   weekday: {
     flex: 1,
     textAlign: 'center',
     fontSize: 12,
-    fontWeight: '600',
-    color: colors.textFaint,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
+    fontWeight: '700',
+    color: colors.textMuted,
+    paddingVertical: spacing.xs,
   },
   week: {
     flexDirection: 'row',

--- a/mobile/src/components/DayCell.tsx
+++ b/mobile/src/components/DayCell.tsx
@@ -9,9 +9,11 @@ interface Props {
   isToday: boolean;
   onPress: () => void;
   onLongPress: () => void;
+  // Display-only: render the day without responding to taps (read-only server).
+  disabled?: boolean;
 }
 
-function DayCell({ day, state, isToday, onPress, onLongPress }: Props) {
+function DayCell({ day, state, isToday, onPress, onLongPress, disabled }: Props) {
   if (day === null) {
     return <View style={styles.cell} />;
   }
@@ -25,12 +27,13 @@ function DayCell({ day, state, isToday, onPress, onLongPress }: Props) {
         onPress={onPress}
         onLongPress={onLongPress}
         delayLongPress={250}
+        disabled={disabled}
         style={({ pressed }) => [
           styles.day,
           filled && { backgroundColor: look.bg },
           look.scheduled && styles.scheduled,
           isToday && styles.today,
-          pressed && styles.pressed,
+          pressed && !disabled && styles.pressed,
         ]}
       >
         <Text

--- a/mobile/src/components/DayCell.tsx
+++ b/mobile/src/components/DayCell.tsx
@@ -33,7 +33,11 @@ function DayCell({ day, state, isToday, onPress, onLongPress }: Props) {
           pressed && styles.pressed,
         ]}
       >
-        <Text style={[styles.dayNum, { color: look.fg }]}>{day}</Text>
+        <Text
+          style={[styles.dayNum, { color: look.fg }, isToday && styles.todayNum]}
+        >
+          {day}
+        </Text>
       </Pressable>
     </View>
   );
@@ -43,7 +47,7 @@ const styles = StyleSheet.create({
   cell: {
     flex: 1,
     aspectRatio: 1,
-    padding: 2,
+    padding: 3,
   },
   day: {
     flex: 1,
@@ -52,13 +56,14 @@ const styles = StyleSheet.create({
     borderRadius: radius.md,
     borderWidth: 1,
     borderColor: colors.border,
+    backgroundColor: colors.surface, // untracked days are white, like the web
   },
   scheduled: {
     borderStyle: 'dashed',
     borderColor: colors.borderStrong,
   },
   today: {
-    borderWidth: 2,
+    borderWidth: 3,
     borderColor: colors.todayRing,
   },
   pressed: {
@@ -67,6 +72,9 @@ const styles = StyleSheet.create({
   dayNum: {
     fontSize: 15,
     fontWeight: '500',
+  },
+  todayNum: {
+    fontWeight: '700',
   },
 });
 

--- a/mobile/src/components/Header.tsx
+++ b/mobile/src/components/Header.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import React, { useRef } from 'react';
+import { Alert, Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import { colors, fonts, spacing } from '../theme';
 
 interface Props {
@@ -12,6 +12,27 @@ interface Props {
 // (internal/embed/html/bases/base.html): the office-building icon, the
 // "Officetracker" wordmark in Calistoga, and a slash-prefixed nav link.
 export default function Header({ rightLabel, onRightPress }: Props) {
+  // iykyk: seven quick taps on the wordmark asks the source of truth.
+  const taps = useRef(0);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const askTheSourceOfTruth = async () => {
+    taps.current += 1;
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => (taps.current = 0), 1500);
+    if (taps.current < 7) return;
+    taps.current = 0;
+
+    const title = 'Is Bailey Butler in the office today?';
+    try {
+      const res = await fetch('https://isbaileybutlerintheoffice.today/raw');
+      const answer = (await res.text()).trim().toLowerCase();
+      Alert.alert(title, answer === 'yes' ? 'Yes.' : 'No.');
+    } catch {
+      Alert.alert(title, 'Unreachable. Assume no.');
+    }
+  };
+
   return (
     <View style={styles.nav}>
       <View style={styles.brand}>
@@ -20,7 +41,9 @@ export default function Header({ rightLabel, onRightPress }: Props) {
           style={styles.icon}
           resizeMode="contain"
         />
-        <Text style={styles.wordmark}>Officetracker</Text>
+        <Pressable onPress={askTheSourceOfTruth} hitSlop={6}>
+          <Text style={styles.wordmark}>Officetracker</Text>
+        </Pressable>
       </View>
       {rightLabel && (
         <Pressable

--- a/mobile/src/components/Header.tsx
+++ b/mobile/src/components/Header.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors, fonts, spacing } from '../theme';
+
+interface Props {
+  // Optional web-style nav link shown on the right (e.g. "/settings").
+  rightLabel?: string;
+  onRightPress?: () => void;
+}
+
+// The pale-cyan brand bar that mirrors the web app's <nav>
+// (internal/embed/html/bases/base.html): the office-building icon, the
+// "Officetracker" wordmark in Calistoga, and a slash-prefixed nav link.
+export default function Header({ rightLabel, onRightPress }: Props) {
+  return (
+    <View style={styles.nav}>
+      <View style={styles.brand}>
+        <Image
+          source={require('../../assets/office-building.png')}
+          style={styles.icon}
+          resizeMode="contain"
+        />
+        <Text style={styles.wordmark}>Officetracker</Text>
+      </View>
+      {rightLabel && (
+        <Pressable
+          onPress={onRightPress}
+          hitSlop={10}
+          style={({ pressed }) => pressed && styles.pressed}
+        >
+          <Text style={styles.link}>{rightLabel}</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  nav: {
+    backgroundColor: colors.navBg,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.lg,
+  },
+  brand: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  icon: {
+    width: 28,
+    height: 28,
+  },
+  wordmark: {
+    fontSize: 24,
+    fontFamily: fonts.wordmark,
+    color: colors.text,
+  },
+  link: {
+    fontSize: 16,
+    color: colors.textMuted,
+  },
+  pressed: { opacity: 0.6 },
+});

--- a/mobile/src/components/Legend.tsx
+++ b/mobile/src/components/Legend.tsx
@@ -36,26 +36,28 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     justifyContent: 'center',
-    gap: spacing.md,
+    rowGap: spacing.sm,
+    columnGap: spacing.lg,
   },
   item: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 6,
+    gap: spacing.sm,
   },
+  // Square swatch with a border, matching the web .legend-color.
   swatch: {
-    width: 12,
-    height: 12,
-    borderRadius: 3,
+    width: 16,
+    height: 16,
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   scheduledSwatch: {
     backgroundColor: 'transparent',
-    borderWidth: 1,
     borderStyle: 'dashed',
     borderColor: colors.borderStrong,
   },
   label: {
-    fontSize: 12,
+    fontSize: 13,
     color: colors.textMuted,
   },
 });

--- a/mobile/src/components/LocationPicker.tsx
+++ b/mobile/src/components/LocationPicker.tsx
@@ -12,8 +12,8 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
-import MapView, { MapPressEvent, Marker, MarkerDragStartEndEvent } from 'react-native-maps';
 import { WebView } from 'react-native-webview';
+import NativeMap, { NativeMapHandle } from './NativeMap';
 import { colors, radius, spacing } from '../theme';
 
 export interface Coord {
@@ -85,7 +85,7 @@ export default function LocationPicker({
   onSelect,
 }: Props) {
   const webRef = useRef<WebView>(null);
-  const mapRef = useRef<MapView>(null);
+  const mapRef = useRef<NativeMapHandle>(null);
   const [center, setCenter] = useState<Coord | null>(null);
   const [coord, setCoord] = useState<Coord | null>(null);
   const [address, setAddress] = useState('');
@@ -157,10 +157,7 @@ export default function LocationPicker({
   // Move the visible map to a coordinate (after an address search).
   function recenter(c: Coord) {
     if (Platform.OS === 'ios') {
-      mapRef.current?.animateToRegion(
-        { ...c, latitudeDelta: DELTA, longitudeDelta: DELTA },
-        350,
-      );
+      mapRef.current?.recenter(c);
     } else {
       webRef.current?.injectJavaScript(
         `window.setLocation(${c.latitude}, ${c.longitude}); true;`,
@@ -253,29 +250,13 @@ export default function LocationPicker({
               <Text style={styles.hint}>Finding your location…</Text>
             </View>
           ) : Platform.OS === 'ios' ? (
-            <MapView
+            <NativeMap
               ref={mapRef}
-              style={styles.map}
-              initialRegion={{
-                latitude: center.latitude,
-                longitude: center.longitude,
-                latitudeDelta: DELTA,
-                longitudeDelta: DELTA,
-              }}
-              onPress={(e: MapPressEvent) =>
-                setCoord(e.nativeEvent.coordinate)
-              }
-            >
-              {coord && (
-                <Marker
-                  draggable
-                  coordinate={coord}
-                  onDragEnd={(e: MarkerDragStartEndEvent) =>
-                    setCoord(e.nativeEvent.coordinate)
-                  }
-                />
-              )}
-            </MapView>
+              center={center}
+              coord={coord}
+              delta={DELTA}
+              onChange={setCoord}
+            />
           ) : (
             <WebView
               ref={webRef}

--- a/mobile/src/components/LocationPicker.tsx
+++ b/mobile/src/components/LocationPicker.tsx
@@ -1,0 +1,374 @@
+import * as Location from 'expo-location';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+import MapView, { MapPressEvent, Marker, MarkerDragStartEndEvent } from 'react-native-maps';
+import { WebView } from 'react-native-webview';
+import { colors, radius, spacing } from '../theme';
+
+export interface Coord {
+  latitude: number;
+  longitude: number;
+}
+
+interface Props {
+  visible: boolean;
+  // Existing location to start from, if any.
+  initial?: Coord | null;
+  onClose: () => void;
+  onSelect: (coord: Coord, label?: string) => void;
+}
+
+// Sensible fallback centre (Sydney) when we can't get a current position.
+const FALLBACK: Coord = { latitude: -33.8688, longitude: 151.2093 };
+
+// ~1km span — a comfortable zoom for picking a building.
+const DELTA = 0.01;
+
+// Android falls back to a self-contained Leaflet map (OpenStreetMap tiles, no
+// API key). iOS uses a native MapView (Apple Maps), which needs no key either.
+// Tapping the map or dragging the pin posts the coordinate back.
+function leafletHtml(c: Coord): string {
+  return `<!DOCTYPE html><html><head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+<style>html,body,#map{height:100%;margin:0;padding:0;}.leaflet-container{background:#e9eef0;}</style>
+</head><body>
+<div id="map"></div>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+  var map = L.map('map').setView([${c.latitude}, ${c.longitude}], 16);
+  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19, attribution: '&copy; OpenStreetMap'
+  }).addTo(map);
+  var marker = L.marker([${c.latitude}, ${c.longitude}], { draggable: true }).addTo(map);
+  function post(ll) {
+    if (window.ReactNativeWebView) {
+      window.ReactNativeWebView.postMessage(JSON.stringify({ lat: ll.lat, lng: ll.lng }));
+    }
+  }
+  map.on('click', function (e) { marker.setLatLng(e.latlng); post(e.latlng); });
+  marker.on('dragend', function () { post(marker.getLatLng()); });
+  window.setLocation = function (lat, lng) {
+    var ll = L.latLng(lat, lng);
+    marker.setLatLng(ll);
+    map.setView(ll, 16);
+    post(ll);
+  };
+  post(marker.getLatLng());
+</script>
+</body></html>`;
+}
+
+function formatPlace(p?: Location.LocationGeocodedAddress): string | undefined {
+  if (!p) return undefined;
+  const line = [p.name || p.street, p.city || p.subregion].filter(Boolean);
+  const s = line.join(', ');
+  return s || undefined;
+}
+
+export default function LocationPicker({
+  visible,
+  initial,
+  onClose,
+  onSelect,
+}: Props) {
+  const webRef = useRef<WebView>(null);
+  const mapRef = useRef<MapView>(null);
+  const [center, setCenter] = useState<Coord | null>(null);
+  const [coord, setCoord] = useState<Coord | null>(null);
+  const [address, setAddress] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Resolve an initial centre each time the modal opens: the existing location,
+  // else the device's current position, else a fallback.
+  useEffect(() => {
+    if (!visible) return;
+    let cancelled = false;
+    setCenter(null);
+    setCoord(null);
+    setAddress('');
+    (async () => {
+      if (initial) {
+        if (!cancelled) {
+          setCenter(initial);
+          setCoord(initial);
+        }
+        return;
+      }
+      try {
+        const perm = await Location.requestForegroundPermissionsAsync();
+        if (perm.status === 'granted') {
+          const pos = await Location.getCurrentPositionAsync({
+            accuracy: Location.Accuracy.Balanced,
+          });
+          if (!cancelled) {
+            const c = {
+              latitude: pos.coords.latitude,
+              longitude: pos.coords.longitude,
+            };
+            setCenter(c);
+            setCoord(c);
+            return;
+          }
+        }
+      } catch {
+        // fall through to fallback
+      }
+      if (!cancelled) {
+        setCenter(FALLBACK);
+        setCoord(FALLBACK);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, initial]);
+
+  // Android-only: Leaflet HTML for the WebView.
+  const html = useMemo(
+    () => (center && Platform.OS !== 'ios' ? leafletHtml(center) : ''),
+    [center],
+  );
+
+  const onWebMessage = useCallback((e: { nativeEvent: { data: string } }) => {
+    try {
+      const m = JSON.parse(e.nativeEvent.data) as { lat: number; lng: number };
+      if (typeof m.lat === 'number' && typeof m.lng === 'number') {
+        setCoord({ latitude: m.lat, longitude: m.lng });
+      }
+    } catch {
+      // ignore malformed messages
+    }
+  }, []);
+
+  // Move the visible map to a coordinate (after an address search).
+  function recenter(c: Coord) {
+    if (Platform.OS === 'ios') {
+      mapRef.current?.animateToRegion(
+        { ...c, latitudeDelta: DELTA, longitudeDelta: DELTA },
+        350,
+      );
+    } else {
+      webRef.current?.injectJavaScript(
+        `window.setLocation(${c.latitude}, ${c.longitude}); true;`,
+      );
+    }
+  }
+
+  async function searchAddress() {
+    const q = address.trim();
+    if (!q) return;
+    setSearching(true);
+    try {
+      const results = await Location.geocodeAsync(q);
+      if (!results.length) {
+        Alert.alert('Not found', 'Could not find that address. Try the map.');
+        return;
+      }
+      const r = results[0];
+      const c = { latitude: r.latitude, longitude: r.longitude };
+      setCoord(c);
+      recenter(c);
+    } catch {
+      Alert.alert('Search failed', 'Could not look up that address.');
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  async function confirm() {
+    if (!coord) return;
+    setSaving(true);
+    let label: string | undefined;
+    try {
+      const places = await Location.reverseGeocodeAsync(coord);
+      label = formatPlace(places[0]);
+    } catch {
+      // label is optional
+    }
+    setSaving(false);
+    onSelect(coord, label);
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      onRequestClose={onClose}
+      presentationStyle="fullScreen"
+    >
+      {/* A fresh provider so safe-area insets are measured for the modal's own
+          native container — the app-root provider reports 0 inside a Modal. */}
+      <SafeAreaProvider>
+      <SafeAreaView style={styles.flex} edges={['top', 'left', 'right']}>
+        <View style={styles.header}>
+          <Pressable onPress={onClose} hitSlop={10}>
+            <Text style={styles.cancel}>Cancel</Text>
+          </Pressable>
+          <Text style={styles.title}>Work location</Text>
+          <View style={styles.headerSpacer} />
+        </View>
+
+        <View style={styles.searchRow}>
+          <TextInput
+            style={styles.input}
+            value={address}
+            onChangeText={setAddress}
+            placeholder="Search an address"
+            placeholderTextColor={colors.textFaint}
+            autoCapitalize="words"
+            returnKeyType="search"
+            onSubmitEditing={searchAddress}
+          />
+          <Pressable
+            style={styles.searchBtn}
+            onPress={searchAddress}
+            disabled={searching}
+          >
+            {searching ? (
+              <ActivityIndicator color="#ffffff" />
+            ) : (
+              <Text style={styles.searchBtnText}>Search</Text>
+            )}
+          </Pressable>
+        </View>
+
+        <View style={styles.mapWrap}>
+          {!center ? (
+            <View style={styles.mapLoading}>
+              <ActivityIndicator color={colors.textMuted} />
+              <Text style={styles.hint}>Finding your location…</Text>
+            </View>
+          ) : Platform.OS === 'ios' ? (
+            <MapView
+              ref={mapRef}
+              style={styles.map}
+              initialRegion={{
+                latitude: center.latitude,
+                longitude: center.longitude,
+                latitudeDelta: DELTA,
+                longitudeDelta: DELTA,
+              }}
+              onPress={(e: MapPressEvent) =>
+                setCoord(e.nativeEvent.coordinate)
+              }
+            >
+              {coord && (
+                <Marker
+                  draggable
+                  coordinate={coord}
+                  onDragEnd={(e: MarkerDragStartEndEvent) =>
+                    setCoord(e.nativeEvent.coordinate)
+                  }
+                />
+              )}
+            </MapView>
+          ) : (
+            <WebView
+              ref={webRef}
+              originWhitelist={['*']}
+              source={{ html }}
+              onMessage={onWebMessage}
+              style={styles.map}
+              scrollEnabled={false}
+            />
+          )}
+        </View>
+
+        <View style={styles.footer}>
+          <Text style={styles.hint}>
+            Tap the map or drag the pin to set where "work" is.
+          </Text>
+          <Pressable
+            style={[styles.confirm, !coord && styles.confirmDisabled]}
+            onPress={confirm}
+            disabled={!coord || saving}
+          >
+            {saving ? (
+              <ActivityIndicator color="#ffffff" />
+            ) : (
+              <Text style={styles.confirmText}>Use this location</Text>
+            )}
+          </Pressable>
+        </View>
+      </SafeAreaView>
+      </SafeAreaProvider>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1, backgroundColor: colors.surface },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  cancel: { fontSize: 16, color: colors.textMuted },
+  title: { fontSize: 16, fontWeight: '700', color: colors.text },
+  headerSpacer: { width: 52 },
+  searchRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    padding: spacing.lg,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.md,
+    fontSize: 15,
+    color: colors.text,
+    backgroundColor: colors.fieldBg,
+  },
+  searchBtn: {
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  searchBtnText: { color: '#ffffff', fontSize: 15, fontWeight: '600' },
+  mapWrap: { flex: 1, overflow: 'hidden' },
+  map: { flex: 1 },
+  mapLoading: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  footer: {
+    padding: spacing.lg,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  hint: {
+    fontSize: 13,
+    color: colors.textFaint,
+    lineHeight: 18,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  confirm: {
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  confirmDisabled: { opacity: 0.5 },
+  confirmText: { color: '#ffffff', fontSize: 15, fontWeight: '600' },
+});

--- a/mobile/src/components/NativeMap.ios.tsx
+++ b/mobile/src/components/NativeMap.ios.tsx
@@ -1,0 +1,76 @@
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import { StyleSheet } from 'react-native';
+import MapView, {
+  MapPressEvent,
+  Marker,
+  MarkerDragStartEndEvent,
+} from 'react-native-maps';
+
+export interface Coord {
+  latitude: number;
+  longitude: number;
+}
+
+export interface NativeMapHandle {
+  recenter: (c: Coord) => void;
+}
+
+interface Props {
+  center: Coord;
+  coord: Coord | null;
+  delta: number;
+  onChange: (c: Coord) => void;
+}
+
+// iOS-only: a native MapView (Apple Maps, no API key). Kept in its own .ios file
+// so react-native-maps — which calls codegenNativeComponent at import time and
+// is unavailable on web/Android — never enters those bundles. Android and web
+// resolve NativeMap.tsx (a no-op) and use the Leaflet WebView instead.
+const NativeMap = forwardRef<NativeMapHandle, Props>(function NativeMap(
+  { center, coord, delta, onChange },
+  ref,
+) {
+  const mapRef = useRef<MapView>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      recenter: (c: Coord) =>
+        mapRef.current?.animateToRegion(
+          { ...c, latitudeDelta: delta, longitudeDelta: delta },
+          350,
+        ),
+    }),
+    [delta],
+  );
+
+  return (
+    <MapView
+      ref={mapRef}
+      style={styles.map}
+      initialRegion={{
+        latitude: center.latitude,
+        longitude: center.longitude,
+        latitudeDelta: delta,
+        longitudeDelta: delta,
+      }}
+      onPress={(e: MapPressEvent) => onChange(e.nativeEvent.coordinate)}
+    >
+      {coord && (
+        <Marker
+          draggable
+          coordinate={coord}
+          onDragEnd={(e: MarkerDragStartEndEvent) =>
+            onChange(e.nativeEvent.coordinate)
+          }
+        />
+      )}
+    </MapView>
+  );
+});
+
+const styles = StyleSheet.create({
+  map: { flex: 1 },
+});
+
+export default NativeMap;

--- a/mobile/src/components/NativeMap.tsx
+++ b/mobile/src/components/NativeMap.tsx
@@ -1,0 +1,27 @@
+import { forwardRef } from 'react';
+
+export interface Coord {
+  latitude: number;
+  longitude: number;
+}
+
+export interface NativeMapHandle {
+  recenter: (c: Coord) => void;
+}
+
+interface Props {
+  center: Coord;
+  coord: Coord | null;
+  delta: number;
+  onChange: (c: Coord) => void;
+}
+
+// Android and web don't use react-native-maps — they render the Leaflet WebView
+// in LocationPicker instead — so this never mounts. It exists only so the import
+// resolves (and react-native-maps stays out of the web/Android bundles). The
+// matching iOS implementation lives in NativeMap.ios.tsx.
+const NativeMap = forwardRef<NativeMapHandle, Props>(function NativeMap() {
+  return null;
+});
+
+export default NativeMap;

--- a/mobile/src/components/ScheduleEditor.tsx
+++ b/mobile/src/components/ScheduleEditor.tsx
@@ -17,9 +17,11 @@ const LABELS: Record<Weekday, string> = {
 interface Props {
   schedule: SchedulePreferences;
   onChange: (day: Weekday, next: AttendanceState) => void;
+  // Display-only: render the schedule without responding to taps (read-only server).
+  disabled?: boolean;
 }
 
-export default function ScheduleEditor({ schedule, onChange }: Props) {
+export default function ScheduleEditor({ schedule, onChange, disabled }: Props) {
   return (
     <View style={styles.row}>
       {WEEKDAYS_LOWER.map((day) => {
@@ -33,10 +35,11 @@ export default function ScheduleEditor({ schedule, onChange }: Props) {
               onPress={() => onChange(day, cycleState(state, 1))}
               onLongPress={() => onChange(day, cycleState(state, -1))}
               delayLongPress={250}
+              disabled={disabled}
               style={({ pressed }) => [
                 styles.cell,
                 filled && { backgroundColor: look.bg },
-                pressed && styles.pressed,
+                pressed && !disabled && styles.pressed,
               ]}
             />
           </View>

--- a/mobile/src/components/Summary.tsx
+++ b/mobile/src/components/Summary.tsx
@@ -1,77 +1,121 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { formatPercent, Stats } from '../stats';
-import { colors, radius, spacing } from '../theme';
+import { colors, spacing } from '../theme';
 
-interface Props {
-  monthLabel: string;
-  month: Stats;
-  year: Stats;
+// One row per tracking-year month, mirroring the web summary table.
+export interface SummaryRow {
+  label: string; // e.g. "October 2025"
+  office: number;
+  total: number;
+  percent: number;
 }
 
-function Cell({ value, label }: { value: string; label: string }) {
+interface Props {
+  rows: SummaryRow[];
+  total: Stats; // aggregate, for the headline
+}
+
+// Column flex weights: a wide month column, three equal numeric columns.
+const COLS = [2, 1, 1, 1];
+
+function Row({
+  cells,
+  header,
+  last,
+}: {
+  cells: string[];
+  header?: boolean;
+  last?: boolean;
+}) {
   return (
-    <View style={styles.statCell}>
-      <Text style={styles.statValue}>{value}</Text>
-      <Text style={styles.statLabel}>{label}</Text>
+    <View style={[styles.row, last && styles.rowLast]}>
+      {cells.map((c, i) => (
+        <View
+          key={i}
+          style={[
+            styles.cell,
+            { flex: COLS[i] },
+            i < cells.length - 1 && styles.cellDivider,
+            header && styles.headerCell,
+          ]}
+        >
+          <Text style={[styles.cellText, header && styles.headerText]}>{c}</Text>
+        </View>
+      ))}
     </View>
   );
 }
 
-function Summary({ monthLabel, month, year }: Props) {
+function Summary({ rows, total }: Props) {
   return (
-    <View style={styles.card}>
-      <View style={styles.row}>
-        <Cell value={`${month.office}/${month.total}`} label={`${monthLabel} office days`} />
-        <View style={styles.divider} />
-        <Cell value={formatPercent(month.percent)} label="this month" />
-      </View>
-      <View style={styles.hr} />
-      <View style={styles.row}>
-        <Cell value={`${year.office}/${year.total}`} label="office days this year" />
-        <View style={styles.divider} />
-        <Cell value={formatPercent(year.percent)} label="year to date" />
+    <View>
+      <Text style={styles.headline}>
+        Present in office for {total.office} out of {total.total} days. (
+        {formatPercent(total.percent)})
+      </Text>
+      <View style={styles.table}>
+        <Row header cells={['Month', 'Present', 'Total', 'Percent']} />
+        {rows.length === 0 ? (
+          <Row last cells={['No tracked days yet.', '', '', '']} />
+        ) : (
+          rows.map((r, i) => (
+            <Row
+              key={r.label}
+              last={i === rows.length - 1}
+              cells={[
+                r.label,
+                String(r.office),
+                String(r.total),
+                formatPercent(r.percent),
+              ]}
+            />
+          ))
+        )}
       </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  card: {
+  headline: {
+    fontSize: 15,
+    color: colors.text,
+    marginBottom: spacing.md,
+    lineHeight: 21,
+  },
+  table: {
     borderWidth: 1,
     borderColor: colors.border,
-    borderRadius: radius.lg,
-    padding: spacing.lg,
-    backgroundColor: colors.surface,
+    overflow: 'hidden',
   },
   row: {
     flexDirection: 'row',
-    alignItems: 'center',
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
   },
-  statCell: {
-    flex: 1,
-    alignItems: 'center',
+  rowLast: {
+    borderBottomWidth: 0,
   },
-  statValue: {
-    fontSize: 24,
+  cell: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.sm,
+    justifyContent: 'center',
+  },
+  cellDivider: {
+    borderRightWidth: 1,
+    borderRightColor: colors.border,
+  },
+  headerCell: {
+    backgroundColor: colors.tableHeaderBg,
+  },
+  cellText: {
+    fontSize: 13,
+    color: colors.textMuted,
+  },
+  headerText: {
     fontWeight: '700',
     color: colors.text,
-  },
-  statLabel: {
-    marginTop: 2,
-    fontSize: 12,
-    color: colors.textMuted,
-    textAlign: 'center',
-  },
-  divider: {
-    width: 1,
-    alignSelf: 'stretch',
-    backgroundColor: colors.border,
-  },
-  hr: {
-    height: 1,
-    backgroundColor: colors.border,
-    marginVertical: spacing.md,
   },
 });
 

--- a/mobile/src/components/WorkLocationBanner.tsx
+++ b/mobile/src/components/WorkLocationBanner.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors, radius, spacing } from '../theme';
+
+interface Props {
+  onPress: () => void;
+  onDismiss: () => void;
+}
+
+// Home-screen prompt to set a work location so office days get marked
+// automatically. Shown only while no location is configured.
+export default function WorkLocationBanner({ onPress, onDismiss }: Props) {
+  return (
+    <View style={styles.banner}>
+      <View style={styles.text}>
+        <Text style={styles.title}>Mark office days automatically</Text>
+        <Text style={styles.body}>
+          Set your work location and Officetracker will tick off office days when
+          you arrive.
+        </Text>
+        <Pressable
+          onPress={onPress}
+          style={({ pressed }) => [styles.cta, pressed && styles.pressed]}
+        >
+          <Text style={styles.ctaText}>Set work location</Text>
+        </Pressable>
+      </View>
+      <Pressable onPress={onDismiss} hitSlop={10} style={styles.dismiss}>
+        <Text style={styles.dismissText}>×</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    backgroundColor: colors.brandTint,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 10,
+    padding: spacing.lg,
+    marginBottom: spacing.md,
+  },
+  text: { flex: 1 },
+  title: { fontSize: 15, fontWeight: '700', color: colors.text },
+  body: {
+    fontSize: 13,
+    color: colors.textMuted,
+    lineHeight: 18,
+    marginTop: 2,
+  },
+  cta: {
+    alignSelf: 'flex-start',
+    marginTop: spacing.md,
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+  },
+  ctaText: { color: '#ffffff', fontSize: 14, fontWeight: '600' },
+  pressed: { opacity: 0.7 },
+  dismiss: {
+    paddingLeft: spacing.md,
+    marginTop: -2,
+  },
+  dismissText: { fontSize: 22, color: colors.textFaint, lineHeight: 22 },
+});

--- a/mobile/src/config.ts
+++ b/mobile/src/config.ts
@@ -1,6 +1,21 @@
 // Default server; users can point elsewhere from the login screen.
 export const DEFAULT_BASE_URL = 'https://officetracker.com.au';
 
+export interface KnownServer {
+  // Shown in the login server picker.
+  label: string;
+  // Base URL connected to (no trailing slash).
+  url: string;
+}
+
+// Servers offered on the login screen. The first entry is the default and must
+// match DEFAULT_BASE_URL. Users can still enter any other instance manually.
+export const KNOWN_SERVERS: KnownServer[] = [
+  { label: 'officetracker.com.au', url: 'https://officetracker.com.au' },
+  { label: 'beta.officetracker.com.au', url: 'https://beta.officetracker.com.au' },
+  { label: 'officetracker.baileys.app', url: 'https://officetracker.baileys.app' },
+];
+
 // Native Auth0 application (react-native-auth0). Client ID is public.
 export const AUTH0_DOMAIN = 'auth.officetracker.com.au';
 export const AUTH0_CLIENT_ID = 'i7HP3uXeIm0ItFiqXRprnRYmU6bJCI6S';

--- a/mobile/src/dates.ts
+++ b/mobile/src/dates.ts
@@ -30,6 +30,28 @@ export function trackingYear(
   return month >= sm ? year + 1 : year;
 }
 
+// calendarYearForMonth maps a 1-indexed calendar month to the calendar year it
+// falls in within the tracking year labelled fy (mirrors form.js / util.Go).
+export function calendarYearForMonth(
+  month: number,
+  fy: number,
+  startMonth: number = DEFAULT_TRACKING_YEAR_START_MONTH,
+): number {
+  const sm = normaliseStartMonth(startMonth);
+  if (sm === 1) return fy;
+  return month >= sm ? fy - 1 : fy;
+}
+
+// trackingMonthOrder returns a month's position (0-11) within the tracking year,
+// so summary rows read start-month-first (mirrors form.js).
+export function trackingMonthOrder(
+  month: number,
+  startMonth: number = DEFAULT_TRACKING_YEAR_START_MONTH,
+): number {
+  const sm = normaliseStartMonth(startMonth);
+  return (month - sm + 12) % 12;
+}
+
 export interface ViewMonth {
   year: number; // calendar year
   month: number; // 1-12

--- a/mobile/src/location.ts
+++ b/mobile/src/location.ts
@@ -1,0 +1,206 @@
+// Background work-location detection.
+//
+// When the user is near their saved "work" location we mark today as Office —
+// unless they've already set the day themselves. This uses a geofence (cheap,
+// survives app restarts and works when the app is backgrounded/terminated)
+// rather than a continuous location stream, plus a one-shot foreground check to
+// catch the case where they're already inside the region when it's configured.
+import * as Location from 'expo-location';
+import * as TaskManager from 'expo-task-manager';
+import { Api } from './api';
+import { DEFAULT_TRACKING_YEAR_START_MONTH, trackingYear } from './dates';
+import { AttendanceState } from './states';
+import {
+  clearWorkLocation,
+  getAutoOfficeHandledDate,
+  getCachedStartMonth,
+  loadConnection,
+  loadWorkLocation,
+  saveWorkLocation,
+  setAutoOfficeHandledDate,
+  WorkLocation,
+} from './storage';
+
+export const GEOFENCE_TASK = 'officetracker-work-geofence';
+const REGION_ID = 'work';
+
+// Device-local YYYY-MM-DD for the given date.
+function localDateKey(d = new Date()): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+// Great-circle distance between two lat/lng points, in metres.
+function distanceMeters(
+  a: { latitude: number; longitude: number },
+  b: { latitude: number; longitude: number },
+): number {
+  const R = 6371000; // earth radius (m)
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLng = toRad(b.longitude - a.longitude);
+  const lat1 = toRad(a.latitude);
+  const lat2 = toRad(b.latitude);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+// A state the user set themselves — auto-marking must never overwrite it. The
+// scheduled/planned variants (and Untracked) are fair game.
+function isUserSet(state: AttendanceState): boolean {
+  return (
+    state === AttendanceState.WorkFromHome ||
+    state === AttendanceState.Office ||
+    state === AttendanceState.Other
+  );
+}
+
+// If today hasn't been set by the user (untracked or only planned), mark it as
+// Office. Guarded so it touches the server at most once per day. Safe to call
+// from the background task or the foreground.
+export async function markOfficeForToday(): Promise<void> {
+  const now = new Date();
+  const dateKey = localDateKey(now);
+  if ((await getAutoOfficeHandledDate()) === dateKey) return;
+
+  const conn = await loadConnection();
+  if (!conn) return;
+
+  const year = now.getFullYear();
+  const month = now.getMonth() + 1; // 1-12
+  const day = now.getDate();
+  const startMonth =
+    (await getCachedStartMonth()) ?? DEFAULT_TRACKING_YEAR_START_MONTH;
+  const fy = trackingYear(year, month, startMonth);
+
+  // No onUnauthorized handler: a background trigger must never sign the user out.
+  const api = new Api(conn);
+
+  try {
+    const yearData = await api.getYear(fy);
+    const current = yearData[month]?.[day] ?? AttendanceState.Untracked;
+    if (isUserSet(current)) {
+      // Respect a day the user set (including a manual WFH/Other).
+      await setAutoOfficeHandledDate(dateKey);
+      return;
+    }
+    await api.putDay(year, month, day, AttendanceState.Office);
+    await setAutoOfficeHandledDate(dateKey);
+  } catch {
+    // Network/auth error — leave today unhandled so a later trigger retries.
+  }
+}
+
+// Geofence handler. Fires on region enter even when the app is backgrounded.
+TaskManager.defineTask(GEOFENCE_TASK, async ({ data, error }) => {
+  if (error) return;
+  const { eventType } = (data ?? {}) as {
+    eventType?: Location.GeofencingEventType;
+  };
+  if (eventType === Location.GeofencingEventType.Enter) {
+    await markOfficeForToday();
+  }
+});
+
+// Requests foreground then background ("Always") permission. Background is what
+// lets the geofence fire while the app isn't open.
+export async function requestTrackingPermissions(): Promise<{
+  foreground: boolean;
+  background: boolean;
+}> {
+  const fg = await Location.requestForegroundPermissionsAsync();
+  if (fg.status !== 'granted') return { foreground: false, background: false };
+  const bg = await Location.requestBackgroundPermissionsAsync();
+  return { foreground: true, background: bg.status === 'granted' };
+}
+
+async function startGeofence(loc: WorkLocation): Promise<void> {
+  if (await TaskManager.isTaskRegisteredAsync(GEOFENCE_TASK)) {
+    try {
+      await Location.stopGeofencingAsync(GEOFENCE_TASK);
+    } catch {
+      // not running — ignore
+    }
+  }
+  await Location.startGeofencingAsync(GEOFENCE_TASK, [
+    {
+      identifier: REGION_ID,
+      latitude: loc.latitude,
+      longitude: loc.longitude,
+      radius: loc.radius,
+      notifyOnEnter: true,
+      notifyOnExit: false,
+    },
+  ]);
+}
+
+async function stopGeofence(): Promise<void> {
+  if (await TaskManager.isTaskRegisteredAsync(GEOFENCE_TASK)) {
+    try {
+      await Location.stopGeofencingAsync(GEOFENCE_TASK);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+// One-shot foreground check: a geofence only fires on a *crossing*, so this
+// covers configuring the location (or opening the app) while already at work.
+export async function checkProximityNow(): Promise<void> {
+  const loc = await loadWorkLocation();
+  if (!loc) return;
+  // Already resolved today — skip the (battery-costly) location fix entirely.
+  if ((await getAutoOfficeHandledDate()) === localDateKey()) return;
+  const { status } = await Location.getForegroundPermissionsAsync();
+  if (status !== 'granted') return;
+  try {
+    const pos = await Location.getCurrentPositionAsync({
+      accuracy: Location.Accuracy.Balanced,
+    });
+    if (distanceMeters(pos.coords, loc) <= loc.radius) {
+      await markOfficeForToday();
+    }
+  } catch {
+    // best effort
+  }
+}
+
+// Persist the location, request permissions, arm the geofence and do an
+// immediate proximity check. Returns whether background tracking is active
+// (false if the user declined the "Always" permission).
+export async function enableWorkTracking(loc: WorkLocation): Promise<boolean> {
+  await saveWorkLocation(loc);
+  const perms = await requestTrackingPermissions();
+  if (perms.background) {
+    await startGeofence(loc);
+  }
+  if (perms.foreground) {
+    await checkProximityNow();
+  }
+  return perms.background;
+}
+
+export async function disableWorkTracking(): Promise<void> {
+  await stopGeofence();
+  await clearWorkLocation();
+}
+
+// Reconciles the running geofence with stored state + current permissions.
+// Called on launch so tracking resumes after the app (or device) restarts.
+export async function syncWorkGeofence(): Promise<void> {
+  const loc = await loadWorkLocation();
+  if (!loc) {
+    await stopGeofence();
+    return;
+  }
+  const { status } = await Location.getBackgroundPermissionsAsync();
+  if (status !== 'granted') {
+    await stopGeofence();
+    return;
+  }
+  await startGeofence(loc);
+}

--- a/mobile/src/screens/CalendarScreen.tsx
+++ b/mobile/src/screens/CalendarScreen.tsx
@@ -58,7 +58,7 @@ export default function CalendarScreen({
     [conn, onUnauthorized],
   );
 
-  // Read-only servers (e.g. the public demo) can be browsed but never written to.
+  // Read-only servers can be browsed but never written to.
   const readOnly = conn.readOnly;
 
   const [view, setView] = useState<ViewMonth>(thisMonth());
@@ -358,35 +358,27 @@ export default function CalendarScreen({
           </View>
 
           <Text style={styles.tip}>
-            {readOnly
-              ? 'This is a read-only demo — attendance is shown but cannot be edited.'
-              : 'Tap a day to cycle through home, office and other; long-press to go back.'}
+            Tap a day to cycle through home, office and other; long-press to go
+            back.
           </Text>
           <View style={styles.legendWrap}>
             <Legend />
           </View>
 
-          {(!readOnly || noteText) && (
-            <View style={styles.section}>
-              <Text style={styles.heading}>Notes</Text>
-              {readOnly ? (
-                <Text style={[styles.notes, styles.notesReadOnly]}>
-                  {noteText}
-                </Text>
-              ) : (
-                <TextInput
-                  style={styles.notes}
-                  value={noteText}
-                  onChangeText={setNoteText}
-                  onBlur={saveNote}
-                  placeholder={`Notes for ${formatMonthYear(view)}…`}
-                  placeholderTextColor={colors.textFaint}
-                  multiline
-                  textAlignVertical="top"
-                />
-              )}
-            </View>
-          )}
+          <View style={styles.section}>
+            <Text style={styles.heading}>Notes</Text>
+            <TextInput
+              style={styles.notes}
+              value={noteText}
+              onChangeText={setNoteText}
+              onBlur={saveNote}
+              editable={!readOnly}
+              placeholder={`Notes for ${formatMonthYear(view)}…`}
+              placeholderTextColor={colors.textFaint}
+              multiline
+              textAlignVertical="top"
+            />
+          </View>
 
           <View style={styles.section}>
             <Text style={styles.heading}>Summary</Text>
@@ -498,8 +490,5 @@ const styles = StyleSheet.create({
     color: colors.text,
     backgroundColor: colors.fieldBg,
     lineHeight: 21,
-  },
-  notesReadOnly: {
-    color: colors.textMuted,
   },
 });

--- a/mobile/src/screens/CalendarScreen.tsx
+++ b/mobile/src/screens/CalendarScreen.tsx
@@ -58,6 +58,9 @@ export default function CalendarScreen({
     [conn, onUnauthorized],
   );
 
+  // Read-only servers (e.g. the public demo) can be browsed but never written to.
+  const readOnly = conn.readOnly;
+
   const [view, setView] = useState<ViewMonth>(thisMonth());
   const [startMonth, setStartMonth] = useState(DEFAULT_TRACKING_YEAR_START_MONTH);
   const fy = trackingYear(view.year, view.month, startMonth);
@@ -178,6 +181,7 @@ export default function CalendarScreen({
 
   const onCycle = useCallback(
     (day: number, direction: 1 | -1) => {
+      if (readOnly) return;
       // Read the live value so rapid taps don't cycle/revert from a stale closure.
       const current =
         yearDataRef.current[view.month]?.[day] ?? AttendanceState.Untracked;
@@ -215,10 +219,11 @@ export default function CalendarScreen({
           }
         });
     },
-    [api, view, fy],
+    [api, view, fy, readOnly],
   );
 
   const saveNote = useCallback(() => {
+    if (readOnly) return;
     const text = noteText;
     const prev = notes[view.month] ?? '';
     if (prev === text) return;
@@ -228,7 +233,7 @@ export default function CalendarScreen({
       setNotes((n) => ({ ...n, [view.month]: prev })); // revert on failure
       Alert.alert('Could not save note', e?.message ?? 'Please try again.');
     });
-  }, [api, noteText, notes, view]);
+  }, [api, noteText, notes, view, readOnly]);
 
   // Save any pending note before leaving the current month/screen.
   const go = (delta: number) => {
@@ -301,7 +306,7 @@ export default function CalendarScreen({
         }
       >
         <View style={styles.body}>
-        {showBanner && (
+        {showBanner && !readOnly && (
           <WorkLocationBanner
             onPress={() => setPickerVisible(true)}
             onDismiss={dismissBanner}
@@ -348,30 +353,40 @@ export default function CalendarScreen({
               month={view.month}
               days={days}
               onCycle={onCycle}
+              readOnly={readOnly}
             />
           </View>
 
           <Text style={styles.tip}>
-            Tap a day to cycle through home, office and other; long-press to go
-            back.
+            {readOnly
+              ? 'This is a read-only demo — attendance is shown but cannot be edited.'
+              : 'Tap a day to cycle through home, office and other; long-press to go back.'}
           </Text>
           <View style={styles.legendWrap}>
             <Legend />
           </View>
 
-          <View style={styles.section}>
-            <Text style={styles.heading}>Notes</Text>
-            <TextInput
-              style={styles.notes}
-              value={noteText}
-              onChangeText={setNoteText}
-              onBlur={saveNote}
-              placeholder={`Notes for ${formatMonthYear(view)}…`}
-              placeholderTextColor={colors.textFaint}
-              multiline
-              textAlignVertical="top"
-            />
-          </View>
+          {(!readOnly || noteText) && (
+            <View style={styles.section}>
+              <Text style={styles.heading}>Notes</Text>
+              {readOnly ? (
+                <Text style={[styles.notes, styles.notesReadOnly]}>
+                  {noteText}
+                </Text>
+              ) : (
+                <TextInput
+                  style={styles.notes}
+                  value={noteText}
+                  onChangeText={setNoteText}
+                  onBlur={saveNote}
+                  placeholder={`Notes for ${formatMonthYear(view)}…`}
+                  placeholderTextColor={colors.textFaint}
+                  multiline
+                  textAlignVertical="top"
+                />
+              )}
+            </View>
+          )}
 
           <View style={styles.section}>
             <Text style={styles.heading}>Summary</Text>
@@ -483,5 +498,8 @@ const styles = StyleSheet.create({
     color: colors.text,
     backgroundColor: colors.fieldBg,
     lineHeight: 21,
+  },
+  notesReadOnly: {
+    color: colors.textMuted,
   },
 });

--- a/mobile/src/screens/CalendarScreen.tsx
+++ b/mobile/src/screens/CalendarScreen.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ActivityIndicator,
   Alert,
-  Image,
+  PanResponder,
   Pressable,
   RefreshControl,
   ScrollView,
@@ -13,21 +13,24 @@ import {
 } from 'react-native';
 import { Api, isUnauthorized, MonthDays } from '../api';
 import Calendar from '../components/Calendar';
+import Header from '../components/Header';
 import Legend from '../components/Legend';
-import Summary from '../components/Summary';
+import Summary, { SummaryRow } from '../components/Summary';
 import {
   addMonths,
+  calendarYearForMonth,
   DEFAULT_TRACKING_YEAR_START_MONTH,
   formatMonthYear,
   MONTH_NAMES,
   thisMonth,
+  trackingMonthOrder,
   trackingYear,
   ViewMonth,
 } from '../dates';
 import { monthStats, yearStats } from '../stats';
 import { AttendanceState, cycleState } from '../states';
 import { Connection } from '../storage';
-import { colors, fonts, radius, spacing } from '../theme';
+import { colors, radius, spacing } from '../theme';
 
 interface Props {
   conn: Connection;
@@ -187,13 +190,42 @@ export default function CalendarScreen({
     onOpenSettings();
   };
 
-  const month = useMemo(
-    () => monthStats(yearData[view.month] ?? {}),
-    [yearData, view.month],
-  );
   const year = useMemo(() => yearStats(yearData), [yearData]);
-  const today = thisMonth();
-  const isThisMonth = view.year === today.year && view.month === today.month;
+
+  // One row per tracked month, ordered start-month-first, mirroring the web
+  // summary table.
+  const summaryRows = useMemo<SummaryRow[]>(() => {
+    return Object.keys(yearData)
+      .map(Number)
+      .map((m) => {
+        const s = monthStats(yearData[m] ?? {});
+        const calYear = calendarYearForMonth(m, fy, startMonth);
+        return { label: `${MONTH_NAMES[m - 1]} ${calYear}`, ...s, month: m };
+      })
+      .filter((r) => r.total > 0)
+      .sort(
+        (a, b) =>
+          trackingMonthOrder(a.month, startMonth) -
+          trackingMonthOrder(b.month, startMonth),
+      );
+  }, [yearData, fy, startMonth]);
+
+  // Swipe the calendar left/right to change months. Built once; reads the
+  // latest navigation handler through a ref to avoid a stale closure.
+  const goRef = useRef(go);
+  goRef.current = go;
+  const monthSwipe = useRef(
+    PanResponder.create({
+      // Only claim clearly-horizontal drags so day taps and vertical scroll
+      // keep working.
+      onMoveShouldSetPanResponder: (_e, g) =>
+        Math.abs(g.dx) > 20 && Math.abs(g.dx) > Math.abs(g.dy) * 1.5,
+      onPanResponderRelease: (_e, g) => {
+        if (g.dx <= -50) goRef.current(1); // swipe left → next month
+        else if (g.dx >= 50) goRef.current(-1); // swipe right → previous month
+      },
+    }),
+  ).current;
 
   return (
     <ScrollView
@@ -210,30 +242,10 @@ export default function CalendarScreen({
         />
       }
     >
-      <View style={styles.brandBar}>
-        <View style={styles.brandLeft}>
-          <Image
-            source={require('../../assets/office-building.png')}
-            style={styles.brandIcon}
-            resizeMode="contain"
-          />
-          <Text style={styles.wordmark}>Officetracker</Text>
-        </View>
-        <Pressable
-          onPress={openSettings}
-          hitSlop={10}
-          style={({ pressed }) => [styles.gear, pressed && styles.pressed]}
-        >
-          <Text style={styles.gearText}>⚙</Text>
-        </Pressable>
-      </View>
+      <Header rightLabel="Settings" onRightPress={openSettings} />
 
-      <View style={styles.titleBlock}>
-        <Text style={styles.month}>{MONTH_NAMES[view.month - 1]}</Text>
-        <Text style={styles.year}>{view.year}</Text>
-      </View>
-
-      <View style={styles.nav}>
+      <View style={styles.body}>
+      <View style={styles.calendarNav}>
         <Pressable
           onPress={() => go(-1)}
           style={({ pressed }) => [styles.navBtn, pressed && styles.pressed]}
@@ -241,14 +253,9 @@ export default function CalendarScreen({
         >
           <Text style={styles.navText}>‹</Text>
         </Pressable>
-        <Pressable
-          onPress={goToday}
-          style={({ pressed }) => [styles.todayBtn, pressed && styles.pressed]}
-        >
-          <Text
-            style={[styles.todayBtnText, isThisMonth && styles.todayBtnTextActive]}
-          >
-            Today
+        <Pressable onPress={goToday} hitSlop={8}>
+          <Text style={styles.monthYear}>
+            {MONTH_NAMES[view.month - 1]} {view.year}
           </Text>
         </Pressable>
         <Pressable
@@ -273,28 +280,25 @@ export default function CalendarScreen({
         </View>
       ) : (
         <>
-          <Calendar
-            year={view.year}
-            month={view.month}
-            days={days}
-            onCycle={onCycle}
-          />
+          <View {...monthSwipe.panHandlers}>
+            <Calendar
+              year={view.year}
+              month={view.month}
+              days={days}
+              onCycle={onCycle}
+            />
+          </View>
 
-          <Text style={styles.tip}>Tap to cycle · long-press to go back</Text>
+          <Text style={styles.tip}>
+            Tap a day to cycle through home, office and other; long-press to go
+            back.
+          </Text>
           <View style={styles.legendWrap}>
             <Legend />
           </View>
 
           <View style={styles.section}>
-            <Summary
-              monthLabel={MONTH_NAMES[view.month - 1]}
-              month={month}
-              year={year}
-            />
-          </View>
-
-          <View style={styles.section}>
-            <Text style={styles.sectionLabel}>Notes</Text>
+            <Text style={styles.heading}>Notes</Text>
             <TextInput
               style={styles.notes}
               value={noteText}
@@ -306,66 +310,35 @@ export default function CalendarScreen({
               textAlignVertical="top"
             />
           </View>
+
+          <View style={styles.section}>
+            <Text style={styles.heading}>Summary</Text>
+            <Summary rows={summaryRows} total={year} />
+          </View>
         </>
       )}
+      </View>
     </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, backgroundColor: colors.bg },
+  flex: { flex: 1, backgroundColor: colors.surface },
   content: {
-    padding: spacing.lg,
     paddingBottom: spacing.xl * 2,
   },
-  brandBar: {
+  body: {
+    padding: spacing.lg,
+  },
+  calendarNav: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-  },
-  brandLeft: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.sm,
-  },
-  brandIcon: {
-    width: 26,
-    height: 26,
-  },
-  wordmark: {
-    fontSize: 20,
-    fontFamily: fonts.wordmark,
-    color: colors.accent,
-  },
-  titleBlock: {
-    flexDirection: 'row',
-    alignItems: 'baseline',
-    gap: spacing.sm,
     marginTop: spacing.lg,
-  },
-  month: {
-    fontSize: 26,
-    fontWeight: '700',
-    color: colors.text,
-  },
-  year: {
-    fontSize: 26,
-    fontWeight: '300',
-    color: colors.textFaint,
-  },
-  gear: {
-    padding: spacing.xs,
-  },
-  gearText: {
-    fontSize: 22,
-    color: colors.textMuted,
-  },
-  nav: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginTop: spacing.md,
-    marginBottom: spacing.lg,
+    marginBottom: spacing.md,
+    // Match the 3px padding inside each day cell so the arrows line up with the
+    // Monday and Sunday columns below.
+    paddingHorizontal: 3,
   },
   navBtn: {
     width: 44,
@@ -375,22 +348,16 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.border,
     borderRadius: radius.md,
+    backgroundColor: colors.cellBg,
   },
   navText: {
     fontSize: 22,
     color: colors.text,
     lineHeight: 24,
   },
-  todayBtn: {
-    paddingVertical: spacing.sm,
-    paddingHorizontal: spacing.lg,
-  },
-  todayBtnText: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: colors.textMuted,
-  },
-  todayBtnTextActive: {
+  monthYear: {
+    fontSize: 22,
+    fontWeight: '700',
     color: colors.text,
   },
   pressed: { opacity: 0.6 },
@@ -422,6 +389,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     fontSize: 12,
     color: colors.textFaint,
+    lineHeight: 17,
   },
   legendWrap: {
     marginTop: spacing.md,
@@ -429,13 +397,11 @@ const styles = StyleSheet.create({
   section: {
     marginTop: spacing.xl,
   },
-  sectionLabel: {
-    fontSize: 13,
-    fontWeight: '600',
+  heading: {
+    fontSize: 18,
+    fontWeight: '700',
     color: colors.text,
     marginBottom: spacing.sm,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
   },
   notes: {
     minHeight: 96,

--- a/mobile/src/screens/CalendarScreen.tsx
+++ b/mobile/src/screens/CalendarScreen.tsx
@@ -15,7 +15,9 @@ import { Api, isUnauthorized, MonthDays } from '../api';
 import Calendar from '../components/Calendar';
 import Header from '../components/Header';
 import Legend from '../components/Legend';
+import LocationPicker, { Coord } from '../components/LocationPicker';
 import Summary, { SummaryRow } from '../components/Summary';
+import WorkLocationBanner from '../components/WorkLocationBanner';
 import {
   addMonths,
   calendarYearForMonth,
@@ -27,9 +29,17 @@ import {
   trackingYear,
   ViewMonth,
 } from '../dates';
+import { enableWorkTracking } from '../location';
 import { monthStats, yearStats } from '../stats';
 import { AttendanceState, cycleState } from '../states';
-import { Connection } from '../storage';
+import {
+  cacheStartMonth,
+  Connection,
+  DEFAULT_WORK_RADIUS,
+  dismissWorkBanner,
+  isWorkBannerDismissed,
+  loadWorkLocation,
+} from '../storage';
 import { colors, radius, spacing } from '../theme';
 
 interface Props {
@@ -63,6 +73,48 @@ export default function CalendarScreen({
   // Local, possibly-unsaved note text for the current month.
   const [noteText, setNoteText] = useState('');
 
+  // Work-location prompt + picker.
+  const [showBanner, setShowBanner] = useState(false);
+  const [pickerVisible, setPickerVisible] = useState(false);
+
+  // Show the banner only when no work location is set and it wasn't dismissed.
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([loadWorkLocation(), isWorkBannerDismissed()]).then(
+      ([loc, dismissed]) => {
+        if (!cancelled) setShowBanner(!loc && !dismissed);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onPickLocation = useCallback(
+    async (coord: Coord, label?: string) => {
+      setPickerVisible(false);
+      setShowBanner(false);
+      const background = await enableWorkTracking({
+        latitude: coord.latitude,
+        longitude: coord.longitude,
+        radius: DEFAULT_WORK_RADIUS,
+        label,
+      });
+      if (!background) {
+        Alert.alert(
+          'Work location saved',
+          'To mark office days while the app is closed, allow "Always" location access for Officetracker in your device settings.',
+        );
+      }
+    },
+    [],
+  );
+
+  const dismissBanner = useCallback(() => {
+    setShowBanner(false);
+    dismissWorkBanner();
+  }, []);
+
   // Live refs so optimistic callbacks read current state (not a stale closure)
   // and a late refetch can confirm we're still on the same tracking year.
   const fyRef = useRef(fy);
@@ -78,6 +130,8 @@ export default function CalendarScreen({
       .getSettings()
       .then((s) => {
         if (!cancelled) setStartMonth(s.trackingYearStartMonth);
+        // Cache for the background geofence task, which can't fetch settings.
+        cacheStartMonth(s.trackingYearStartMonth);
       })
       .catch(() => {});
     return () => {
@@ -228,23 +282,31 @@ export default function CalendarScreen({
   ).current;
 
   return (
-    <ScrollView
-      style={styles.flex}
-      contentContainerStyle={styles.content}
-      keyboardShouldPersistTaps="handled"
-      keyboardDismissMode="interactive"
-      automaticallyAdjustKeyboardInsets
-      refreshControl={
-        <RefreshControl
-          refreshing={refreshing}
-          onRefresh={() => load(fy, true)}
-          tintColor={colors.textMuted}
-        />
-      }
-    >
+    <View style={styles.screen}>
+      {/* Fixed nav bar — pull-to-refresh only scrolls the content below it. */}
       <Header rightLabel="Settings" onRightPress={openSettings} />
 
-      <View style={styles.body}>
+      <ScrollView
+        style={styles.flex}
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="interactive"
+        automaticallyAdjustKeyboardInsets
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => load(fy, true)}
+            tintColor={colors.textMuted}
+          />
+        }
+      >
+        <View style={styles.body}>
+        {showBanner && (
+          <WorkLocationBanner
+            onPress={() => setPickerVisible(true)}
+            onDismiss={dismissBanner}
+          />
+        )}
       <View style={styles.calendarNav}>
         <Pressable
           onPress={() => go(-1)}
@@ -317,12 +379,20 @@ export default function CalendarScreen({
           </View>
         </>
       )}
-      </View>
-    </ScrollView>
+        </View>
+      </ScrollView>
+
+      <LocationPicker
+        visible={pickerVisible}
+        onClose={() => setPickerVisible(false)}
+        onSelect={onPickLocation}
+      />
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: colors.surface },
   flex: { flex: 1, backgroundColor: colors.surface },
   content: {
     paddingBottom: spacing.xl * 2,

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-native';
 import { useAuth0 } from 'react-native-auth0';
 import { exchangeNativeToken, fetchServerMeta, ServerMeta } from '../api';
-import { AUTH0_SCHEME, DEFAULT_BASE_URL } from '../config';
+import { AUTH0_SCHEME, DEFAULT_BASE_URL, KNOWN_SERVERS } from '../config';
 import { Connection, saveConnection } from '../storage';
 import { colors, fonts, radius, spacing } from '../theme';
 
@@ -35,20 +35,34 @@ export default function LoginScreen({
 }: Props) {
   const { authorize } = useAuth0();
   const [baseUrl, setBaseUrl] = useState(initialBaseUrl ?? DEFAULT_BASE_URL);
-  const [advanced, setAdvanced] = useState(false);
+  // Manual entry is for instances not in the known list. Start in manual mode
+  // only when resuming with a previously-used server that isn't a known one.
+  const [manual, setManual] = useState(
+    () =>
+      !!initialBaseUrl &&
+      !KNOWN_SERVERS.some((s) => s.url === normaliseUrl(initialBaseUrl)),
+  );
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Cached capabilities of the entered server, probed when the field changes so
-  // we can relabel the button and hint that no sign-in is needed.
+  // Cached capabilities of the chosen server, probed when the selection changes
+  // so we can relabel the button and hint that no sign-in is needed.
   const [serverMeta, setServerMeta] = useState<ServerMeta | null>(null);
 
   const normalised = normaliseUrl(baseUrl);
   const anonymous = serverMeta?.auth === 'none';
 
-  // Probe the server's /api/v1/meta so the UI reflects an anonymous server
-  // before the user commits. Runs on blur of the server field.
-  async function probeServer() {
-    setServerMeta(await fetchServerMeta(normaliseUrl(baseUrl)));
+  // Probe a server's /api/v1/meta so the UI reflects an anonymous server before
+  // the user commits. Runs when a list item is picked, or on blur of the field.
+  async function probeServer(url: string = baseUrl) {
+    setServerMeta(await fetchServerMeta(normaliseUrl(url)));
+  }
+
+  // Pick one of the known servers.
+  function selectServer(url: string) {
+    setManual(false);
+    setBaseUrl(url);
+    setServerMeta(null);
+    probeServer(url);
   }
 
   async function connect() {
@@ -125,14 +139,92 @@ export default function LoginScreen({
         <View style={styles.actions}>
           {error && <Text style={styles.error}>{error}</Text>}
 
+          {/* Server picker — choose a known instance, or enter one manually. */}
+          <Text style={styles.label}>Server</Text>
+          <View style={styles.serverList}>
+            {KNOWN_SERVERS.map((s) => {
+              const selected = !manual && normalised === s.url;
+              return (
+                <Pressable
+                  key={s.url}
+                  onPress={() => selectServer(s.url)}
+                  disabled={busy}
+                  style={({ pressed }) => [
+                    styles.serverRow,
+                    selected && styles.serverRowSelected,
+                    pressed && styles.serverRowPressed,
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.serverLabel,
+                      selected && styles.serverLabelSelected,
+                    ]}
+                  >
+                    {s.label}
+                  </Text>
+                  {selected && <Text style={styles.check}>✓</Text>}
+                </Pressable>
+              );
+            })}
+            <Pressable
+              onPress={() => {
+                setManual(true);
+                setBaseUrl('');
+                setServerMeta(null);
+              }}
+              disabled={busy}
+              style={({ pressed }) => [
+                styles.serverRow,
+                manual && styles.serverRowSelected,
+                pressed && styles.serverRowPressed,
+              ]}
+            >
+              <Text
+                style={[styles.serverLabel, manual && styles.serverLabelSelected]}
+              >
+                Enter a different server…
+              </Text>
+              {manual && <Text style={styles.check}>✓</Text>}
+            </Pressable>
+          </View>
+
+          {manual && (
+            <TextInput
+              style={styles.input}
+              value={baseUrl}
+              onChangeText={(t) => {
+                setBaseUrl(t);
+                // A new URL invalidates the previous probe.
+                setServerMeta(null);
+              }}
+              onBlur={() => probeServer()}
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoFocus
+              keyboardType="url"
+              inputMode="url"
+              placeholder={DEFAULT_BASE_URL}
+              placeholderTextColor={colors.textFaint}
+              editable={!busy}
+            />
+          )}
+
+          {anonymous && (
+            <Text style={styles.hint}>
+              This server doesn&apos;t require sign in — it&apos;s a read-only
+              demo.
+            </Text>
+          )}
+
           <Pressable
             style={({ pressed }) => [
               styles.button,
               pressed && styles.buttonPressed,
-              busy && styles.buttonDisabled,
+              (busy || (manual && !baseUrl.trim())) && styles.buttonDisabled,
             ]}
             onPress={connect}
-            disabled={busy}
+            disabled={busy || (manual && !baseUrl.trim())}
           >
             {busy ? (
               <ActivityIndicator color="#ffffff" />
@@ -142,38 +234,6 @@ export default function LoginScreen({
               </Text>
             )}
           </Pressable>
-
-          {advanced ? (
-            <View style={styles.advanced}>
-              <Text style={styles.label}>Server</Text>
-              <TextInput
-                style={styles.input}
-                value={baseUrl}
-                onChangeText={(t) => {
-                  setBaseUrl(t);
-                  // A new URL invalidates the previous probe.
-                  setServerMeta(null);
-                }}
-                onBlur={probeServer}
-                autoCapitalize="none"
-                autoCorrect={false}
-                keyboardType="url"
-                inputMode="url"
-                placeholder={DEFAULT_BASE_URL}
-                placeholderTextColor={colors.textFaint}
-                editable={!busy}
-              />
-              <Text style={styles.hint}>
-                {anonymous
-                  ? "This server doesn't require sign in — it's a read-only demo."
-                  : 'Change this only if you use a different Office Tracker instance.'}
-              </Text>
-            </View>
-          ) : (
-            <Pressable onPress={() => setAdvanced(true)} hitSlop={8} disabled={busy}>
-              <Text style={styles.advancedLink}>Use a different server</Text>
-            </Pressable>
-          )}
 
           {onCancel && (
             <Pressable style={styles.cancel} onPress={onCancel} disabled={busy}>
@@ -226,6 +286,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   button: {
+    marginTop: spacing.lg,
     backgroundColor: colors.accent,
     borderRadius: radius.md,
     paddingVertical: spacing.md + 2,
@@ -234,20 +295,36 @@ const styles = StyleSheet.create({
   buttonPressed: { opacity: 0.8 },
   buttonDisabled: { opacity: 0.6 },
   buttonText: { color: '#ffffff', fontSize: 16, fontWeight: '600' },
-  advancedLink: {
-    marginTop: spacing.lg,
-    textAlign: 'center',
-    color: colors.textMuted,
-    fontSize: 14,
-  },
-  advanced: { marginTop: spacing.lg },
   label: {
     fontSize: 13,
     fontWeight: '600',
     color: colors.text,
-    marginBottom: spacing.xs,
+    marginBottom: spacing.sm,
   },
+  serverList: {
+    gap: spacing.sm,
+  },
+  serverRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.md,
+    backgroundColor: colors.fieldBg,
+  },
+  serverRowSelected: {
+    borderColor: colors.accent,
+    backgroundColor: colors.brandTint,
+  },
+  serverRowPressed: { opacity: 0.6 },
+  serverLabel: { fontSize: 15, color: colors.text },
+  serverLabelSelected: { fontWeight: '700', color: colors.accent },
+  check: { fontSize: 16, fontWeight: '700', color: colors.accent },
   input: {
+    marginTop: spacing.sm,
     borderWidth: 1,
     borderColor: colors.border,
     borderRadius: radius.md,

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -46,8 +46,16 @@ export default function LoginScreen({
     setBusy(true);
     try {
       const credentials = await authorize(
-        { scope: 'openid profile email' },
-        { customScheme: AUTH0_SCHEME },
+        // Always show a fresh login screen instead of silently reusing a cached
+        // Auth0 session. prompt=login asks the server to re-prompt, and
+        // ephemeralSession runs the iOS web flow in a private session that
+        // doesn't share Safari's cookies — so no SSO session lingers after a
+        // sign-out and signing back in actually asks for credentials.
+        {
+          scope: 'openid profile email',
+          additionalParameters: { prompt: 'login' },
+        },
+        { customScheme: AUTH0_SCHEME, ephemeralSession: true },
       );
       if (!credentials?.idToken) {
         // User cancelled the Auth0 prompt.

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -235,13 +235,6 @@ export default function LoginScreen({
                   editable={!busy}
                 />
               )}
-
-              {anonymous && (
-                <Text style={styles.hint}>
-                  This server doesn&apos;t require sign in — it&apos;s a
-                  read-only demo.
-                </Text>
-              )}
             </View>
           ) : (
             <Pressable
@@ -357,12 +350,6 @@ const styles = StyleSheet.create({
     fontSize: 15,
     color: colors.text,
     backgroundColor: colors.fieldBg,
-  },
-  hint: {
-    marginTop: spacing.xs,
-    fontSize: 12,
-    color: colors.textFaint,
-    lineHeight: 17,
   },
   cancel: {
     marginTop: spacing.md,

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -35,6 +35,9 @@ export default function LoginScreen({
 }: Props) {
   const { authorize } = useAuth0();
   const [baseUrl, setBaseUrl] = useState(initialBaseUrl ?? DEFAULT_BASE_URL);
+  // The server picker is hidden behind "Use a different server" so the initial
+  // screen stays a single Sign in button against the default server.
+  const [advanced, setAdvanced] = useState(false);
   // Manual entry is for instances not in the known list. Start in manual mode
   // only when resuming with a previously-used server that isn't a known one.
   const [manual, setManual] = useState(
@@ -139,84 +142,6 @@ export default function LoginScreen({
         <View style={styles.actions}>
           {error && <Text style={styles.error}>{error}</Text>}
 
-          {/* Server picker — choose a known instance, or enter one manually. */}
-          <Text style={styles.label}>Server</Text>
-          <View style={styles.serverList}>
-            {KNOWN_SERVERS.map((s) => {
-              const selected = !manual && normalised === s.url;
-              return (
-                <Pressable
-                  key={s.url}
-                  onPress={() => selectServer(s.url)}
-                  disabled={busy}
-                  style={({ pressed }) => [
-                    styles.serverRow,
-                    selected && styles.serverRowSelected,
-                    pressed && styles.serverRowPressed,
-                  ]}
-                >
-                  <Text
-                    style={[
-                      styles.serverLabel,
-                      selected && styles.serverLabelSelected,
-                    ]}
-                  >
-                    {s.label}
-                  </Text>
-                  {selected && <Text style={styles.check}>✓</Text>}
-                </Pressable>
-              );
-            })}
-            <Pressable
-              onPress={() => {
-                setManual(true);
-                setBaseUrl('');
-                setServerMeta(null);
-              }}
-              disabled={busy}
-              style={({ pressed }) => [
-                styles.serverRow,
-                manual && styles.serverRowSelected,
-                pressed && styles.serverRowPressed,
-              ]}
-            >
-              <Text
-                style={[styles.serverLabel, manual && styles.serverLabelSelected]}
-              >
-                Enter a different server…
-              </Text>
-              {manual && <Text style={styles.check}>✓</Text>}
-            </Pressable>
-          </View>
-
-          {manual && (
-            <TextInput
-              style={styles.input}
-              value={baseUrl}
-              onChangeText={(t) => {
-                setBaseUrl(t);
-                // A new URL invalidates the previous probe.
-                setServerMeta(null);
-              }}
-              onBlur={() => probeServer()}
-              autoCapitalize="none"
-              autoCorrect={false}
-              autoFocus
-              keyboardType="url"
-              inputMode="url"
-              placeholder={DEFAULT_BASE_URL}
-              placeholderTextColor={colors.textFaint}
-              editable={!busy}
-            />
-          )}
-
-          {anonymous && (
-            <Text style={styles.hint}>
-              This server doesn&apos;t require sign in — it&apos;s a read-only
-              demo.
-            </Text>
-          )}
-
           <Pressable
             style={({ pressed }) => [
               styles.button,
@@ -234,6 +159,99 @@ export default function LoginScreen({
               </Text>
             )}
           </Pressable>
+
+          {advanced ? (
+            <View style={styles.advanced}>
+              {/* Choose a known instance, or enter one manually. */}
+              <Text style={styles.label}>Server</Text>
+              <View style={styles.serverList}>
+                {KNOWN_SERVERS.map((s) => {
+                  const selected = !manual && normalised === s.url;
+                  return (
+                    <Pressable
+                      key={s.url}
+                      onPress={() => selectServer(s.url)}
+                      disabled={busy}
+                      style={({ pressed }) => [
+                        styles.serverRow,
+                        selected && styles.serverRowSelected,
+                        pressed && styles.serverRowPressed,
+                      ]}
+                    >
+                      <Text
+                        style={[
+                          styles.serverLabel,
+                          selected && styles.serverLabelSelected,
+                        ]}
+                      >
+                        {s.label}
+                      </Text>
+                      {selected && <Text style={styles.check}>✓</Text>}
+                    </Pressable>
+                  );
+                })}
+                <Pressable
+                  onPress={() => {
+                    setManual(true);
+                    setBaseUrl('');
+                    setServerMeta(null);
+                  }}
+                  disabled={busy}
+                  style={({ pressed }) => [
+                    styles.serverRow,
+                    manual && styles.serverRowSelected,
+                    pressed && styles.serverRowPressed,
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.serverLabel,
+                      manual && styles.serverLabelSelected,
+                    ]}
+                  >
+                    Enter a different server…
+                  </Text>
+                  {manual && <Text style={styles.check}>✓</Text>}
+                </Pressable>
+              </View>
+
+              {manual && (
+                <TextInput
+                  style={styles.input}
+                  value={baseUrl}
+                  onChangeText={(t) => {
+                    setBaseUrl(t);
+                    // A new URL invalidates the previous probe.
+                    setServerMeta(null);
+                  }}
+                  onBlur={() => probeServer()}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  autoFocus
+                  keyboardType="url"
+                  inputMode="url"
+                  placeholder={DEFAULT_BASE_URL}
+                  placeholderTextColor={colors.textFaint}
+                  editable={!busy}
+                />
+              )}
+
+              {anonymous && (
+                <Text style={styles.hint}>
+                  This server doesn&apos;t require sign in — it&apos;s a
+                  read-only demo.
+                </Text>
+              )}
+            </View>
+          ) : (
+            <Pressable
+              onPress={() => setAdvanced(true)}
+              hitSlop={8}
+              disabled={busy}
+            >
+              <Text style={styles.advancedLink}>Use a different server</Text>
+            </Pressable>
+          )}
 
           {onCancel && (
             <Pressable style={styles.cancel} onPress={onCancel} disabled={busy}>
@@ -286,7 +304,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   button: {
-    marginTop: spacing.lg,
     backgroundColor: colors.accent,
     borderRadius: radius.md,
     paddingVertical: spacing.md + 2,
@@ -295,6 +312,13 @@ const styles = StyleSheet.create({
   buttonPressed: { opacity: 0.8 },
   buttonDisabled: { opacity: 0.6 },
   buttonText: { color: '#ffffff', fontSize: 16, fontWeight: '600' },
+  advancedLink: {
+    marginTop: spacing.lg,
+    textAlign: 'center',
+    color: colors.textMuted,
+    fontSize: 14,
+  },
+  advanced: { marginTop: spacing.lg },
   label: {
     fontSize: 13,
     fontWeight: '600',

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -11,7 +11,7 @@ import {
   View,
 } from 'react-native';
 import { useAuth0 } from 'react-native-auth0';
-import { exchangeNativeToken } from '../api';
+import { exchangeNativeToken, fetchServerMeta, ServerMeta } from '../api';
 import { AUTH0_SCHEME, DEFAULT_BASE_URL } from '../config';
 import { Connection, saveConnection } from '../storage';
 import { colors, fonts, radius, spacing } from '../theme';
@@ -38,13 +38,40 @@ export default function LoginScreen({
   const [advanced, setAdvanced] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Cached capabilities of the entered server, probed when the field changes so
+  // we can relabel the button and hint that no sign-in is needed.
+  const [serverMeta, setServerMeta] = useState<ServerMeta | null>(null);
 
   const normalised = normaliseUrl(baseUrl);
+  const anonymous = serverMeta?.auth === 'none';
 
-  async function signIn() {
+  // Probe the server's /api/v1/meta so the UI reflects an anonymous server
+  // before the user commits. Runs on blur of the server field.
+  async function probeServer() {
+    setServerMeta(await fetchServerMeta(normaliseUrl(baseUrl)));
+  }
+
+  async function connect() {
     setError(null);
     setBusy(true);
     try {
+      // Ask the server how to authenticate (cheap, unauthenticated probe).
+      const meta = await fetchServerMeta(normalised);
+      setServerMeta(meta);
+
+      // Anonymous server: no Auth0 prompt and no token exchange — connect with
+      // an empty token straight away.
+      if (meta.auth === 'none') {
+        const conn: Connection = {
+          baseUrl: normalised,
+          token: '',
+          readOnly: meta.readOnly,
+        };
+        await saveConnection(conn);
+        onConnected(conn);
+        return;
+      }
+
       const credentials = await authorize(
         // Always show a fresh login screen instead of silently reusing a cached
         // Auth0 session. prompt=login asks the server to re-prompt, and
@@ -64,7 +91,11 @@ export default function LoginScreen({
       }
 
       const token = await exchangeNativeToken(normalised, credentials.idToken);
-      const conn: Connection = { baseUrl: normalised, token };
+      const conn: Connection = {
+        baseUrl: normalised,
+        token,
+        readOnly: meta.readOnly,
+      };
       await saveConnection(conn);
       onConnected(conn);
     } catch (e: any) {
@@ -100,13 +131,15 @@ export default function LoginScreen({
               pressed && styles.buttonPressed,
               busy && styles.buttonDisabled,
             ]}
-            onPress={signIn}
+            onPress={connect}
             disabled={busy}
           >
             {busy ? (
               <ActivityIndicator color="#ffffff" />
             ) : (
-              <Text style={styles.buttonText}>Sign in</Text>
+              <Text style={styles.buttonText}>
+                {anonymous ? 'Continue' : 'Sign in'}
+              </Text>
             )}
           </Pressable>
 
@@ -116,7 +149,12 @@ export default function LoginScreen({
               <TextInput
                 style={styles.input}
                 value={baseUrl}
-                onChangeText={setBaseUrl}
+                onChangeText={(t) => {
+                  setBaseUrl(t);
+                  // A new URL invalidates the previous probe.
+                  setServerMeta(null);
+                }}
+                onBlur={probeServer}
                 autoCapitalize="none"
                 autoCorrect={false}
                 keyboardType="url"
@@ -126,7 +164,9 @@ export default function LoginScreen({
                 editable={!busy}
               />
               <Text style={styles.hint}>
-                Change this only if you use a different Office Tracker instance.
+                {anonymous
+                  ? "This server doesn't require sign in — it's a read-only demo."
+                  : 'Change this only if you use a different Office Tracker instance.'}
               </Text>
             </View>
           ) : (

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -23,7 +23,6 @@ import { colors, radius, spacing } from '../theme';
 interface Props {
   conn: Connection;
   onClose: () => void;
-  onSignInAgain: () => void;
   onUnauthorized: () => void;
   onDisconnect: () => void;
 }
@@ -36,7 +35,6 @@ function formatDate(iso: string): string {
 export default function SettingsScreen({
   conn,
   onClose,
-  onSignInAgain,
   onUnauthorized,
   onDisconnect,
 }: Props) {
@@ -358,16 +356,6 @@ export default function SettingsScreen({
               </Pressable>
             </View>
           )}
-
-          {/* Connection */}
-          <Text style={styles.sectionLabel}>Connection</Text>
-          <View style={styles.card}>
-            <Text style={styles.fieldLabel}>Server</Text>
-            <Text style={styles.fieldValue}>{conn.baseUrl}</Text>
-          </View>
-          <Pressable style={styles.button} onPress={onSignInAgain}>
-            <Text style={styles.buttonText}>Sign in again</Text>
-          </Pressable>
 
           <Pressable style={[styles.button, styles.danger]} onPress={signOut}>
             <Text style={[styles.buttonText, styles.dangerText]}>Sign out</Text>

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -12,6 +12,7 @@ import {
   View,
 } from 'react-native';
 import { Api, isUnauthorized, Settings, TokenInfo, Weekday } from '../api';
+import Header from '../components/Header';
 import Legend from '../components/Legend';
 import ScheduleEditor from '../components/ScheduleEditor';
 import { MONTH_NAMES } from '../dates';
@@ -193,12 +194,10 @@ export default function SettingsScreen({
         />
       }
     >
-      <View style={styles.header}>
-        <Text style={styles.title}>Settings</Text>
-        <Pressable onPress={onClose} hitSlop={10}>
-          <Text style={styles.done}>Done</Text>
-        </Pressable>
-      </View>
+      <Header rightLabel="Done" onRightPress={onClose} />
+
+      <View style={styles.body}>
+      <Text style={styles.screenTitle}>Settings</Text>
 
       {loading ? (
         <View style={styles.loading}>
@@ -375,21 +374,21 @@ export default function SettingsScreen({
           </Pressable>
         </>
       )}
+      </View>
     </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, backgroundColor: colors.bg },
-  content: { padding: spacing.lg, paddingBottom: spacing.xl * 2 },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: spacing.sm,
+  flex: { flex: 1, backgroundColor: colors.surface },
+  content: { paddingBottom: spacing.xl * 2 },
+  body: { padding: spacing.lg },
+  screenTitle: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: colors.text,
+    marginTop: spacing.sm,
   },
-  title: { fontSize: 24, fontWeight: '700', color: colors.text },
-  done: { fontSize: 16, fontWeight: '600', color: colors.accent },
   monthRow: { gap: spacing.sm, paddingVertical: 2 },
   monthChip: {
     paddingVertical: spacing.sm,
@@ -407,25 +406,24 @@ const styles = StyleSheet.create({
   loading: { paddingVertical: spacing.xl * 2 },
   errorText: { color: colors.danger, marginBottom: spacing.md },
   sectionLabel: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: colors.textMuted,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
+    fontSize: 17,
+    fontWeight: '700',
+    color: colors.text,
     marginTop: spacing.xl,
     marginBottom: spacing.sm,
   },
   hint: {
-    fontSize: 12,
+    fontSize: 13,
     color: colors.textFaint,
-    lineHeight: 17,
+    lineHeight: 18,
     marginBottom: spacing.sm,
   },
   card: {
     borderWidth: 1,
     borderColor: colors.border,
-    borderRadius: radius.lg,
+    borderRadius: 10,
     padding: spacing.lg,
+    backgroundColor: colors.surface,
   },
   fieldLabel: { fontSize: 12, color: colors.textMuted, marginBottom: 2 },
   fieldValue: { fontSize: 15, color: colors.text },

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -52,6 +52,9 @@ export default function SettingsScreen({
     [conn, onUnauthorized],
   );
 
+  // Read-only servers (e.g. the public demo) hide every account/write affordance.
+  const readOnly = conn.readOnly;
+
   const [settings, setSettings] = useState<Settings | null>(null);
   const [tokens, setTokens] = useState<TokenInfo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -76,7 +79,12 @@ export default function SettingsScreen({
       else setLoading(true);
       setError(null);
       try {
-        const [s, t] = await Promise.all([api.getSettings(), api.listTokens()]);
+        // Developer tokens require auth; skip them on a read-only/anonymous
+        // server (the section is hidden, and the call would otherwise 401).
+        const [s, t] = await Promise.all([
+          api.getSettings(),
+          readOnly ? Promise.resolve<TokenInfo[]>([]) : api.listTokens(),
+        ]);
         setSettings(s);
         setTokens(t);
         // Cache for the background geofence task, which can't fetch settings.
@@ -88,7 +96,7 @@ export default function SettingsScreen({
         setRefreshing(false);
       }
     },
-    [api],
+    [api, readOnly],
   );
 
   useEffect(() => {
@@ -217,6 +225,21 @@ export default function SettingsScreen({
   }
 
   function signOut() {
+    // A read-only/anonymous connection has no session to revoke — just drop it.
+    if (readOnly) {
+      Alert.alert('Disconnect', 'Disconnect from this server?', [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Disconnect',
+          style: 'destructive',
+          onPress: async () => {
+            await clearConnection();
+            onDisconnect();
+          },
+        },
+      ]);
+      return;
+    }
     Alert.alert('Sign out', 'Sign out of Officetracker on this device?', [
       { text: 'Cancel', style: 'cancel' },
       {
@@ -266,44 +289,50 @@ export default function SettingsScreen({
         </View>
       ) : (
         <>
-          {/* Accounts */}
-          <Text style={styles.sectionLabel}>Accounts</Text>
-          <View style={styles.card}>
-            {settings && settings.linkedAccounts.length > 0 ? (
-              settings.linkedAccounts.map((a, i) => (
-                <View key={`${a.provider}-${i}`}>
-                  {i > 0 && <View style={styles.hr} />}
-                  <Text style={styles.fieldLabel}>{a.providerDisplay}</Text>
-                  <Text style={styles.fieldValue}>{a.nickname || '—'}</Text>
-                </View>
-              ))
-            ) : (
-              <Text style={styles.muted}>No linked accounts.</Text>
-            )}
-          </View>
-          <Pressable
-            style={styles.button}
-            onPress={addAccount}
-            disabled={addingAccount}
-          >
-            {addingAccount ? (
-              <ActivityIndicator color={colors.text} />
-            ) : (
-              <Text style={styles.buttonText}>Add account</Text>
-            )}
-          </Pressable>
+          {/* Accounts (hidden on a read-only/anonymous server) */}
+          {!readOnly && (
+            <>
+              <Text style={styles.sectionLabel}>Accounts</Text>
+              <View style={styles.card}>
+                {settings && settings.linkedAccounts.length > 0 ? (
+                  settings.linkedAccounts.map((a, i) => (
+                    <View key={`${a.provider}-${i}`}>
+                      {i > 0 && <View style={styles.hr} />}
+                      <Text style={styles.fieldLabel}>{a.providerDisplay}</Text>
+                      <Text style={styles.fieldValue}>{a.nickname || '—'}</Text>
+                    </View>
+                  ))
+                ) : (
+                  <Text style={styles.muted}>No linked accounts.</Text>
+                )}
+              </View>
+              <Pressable
+                style={styles.button}
+                onPress={addAccount}
+                disabled={addingAccount}
+              >
+                {addingAccount ? (
+                  <ActivityIndicator color={colors.text} />
+                ) : (
+                  <Text style={styles.buttonText}>Add account</Text>
+                )}
+              </Pressable>
+            </>
+          )}
 
           {/* Planned days */}
           <Text style={styles.sectionLabel}>Planned days</Text>
           <Text style={styles.hint}>
-            Set the days you usually attend. They show as faded "planned" days on
-            the calendar. Tap to cycle, long-press to go back.
+            {readOnly
+              ? 'The days usually attended, shown as faded "planned" days on the calendar.'
+              : 'Set the days you usually attend. They show as faded "planned" days on the calendar. Tap to cycle, long-press to go back.'}
           </Text>
           <View style={styles.card}>
             {settings && (
               <ScheduleEditor
                 schedule={settings.schedule}
                 onChange={cycleSchedule}
+                disabled={readOnly}
               />
             )}
             <View style={styles.legendWrap}>
@@ -331,6 +360,7 @@ export default function SettingsScreen({
                   <Pressable
                     key={month}
                     onPress={() => setTrackingStart(month)}
+                    disabled={readOnly}
                     style={[styles.monthChip, selected && styles.monthChipSelected]}
                   >
                     <Text
@@ -347,7 +377,9 @@ export default function SettingsScreen({
             </ScrollView>
           </View>
 
-          {/* Work location */}
+          {/* Work location (device feature; hidden on a read-only server) */}
+          {!readOnly && (
+            <>
           <Text style={styles.sectionLabel}>Work location</Text>
           <Text style={styles.hint}>
             When you arrive here, Officetracker marks the day as an office day —
@@ -391,8 +423,12 @@ export default function SettingsScreen({
               </>
             )}
           </View>
+            </>
+          )}
 
-          {/* Developer tokens */}
+          {/* Developer tokens (require auth; hidden on a read-only server) */}
+          {!readOnly && (
+            <>
           <Text style={styles.sectionLabel}>Developer tokens</Text>
           <Text style={styles.hint}>
             API tokens for scripts or the MCP server. Sent as a Bearer token.
@@ -457,9 +493,13 @@ export default function SettingsScreen({
               </Pressable>
             </View>
           )}
+            </>
+          )}
 
           <Pressable style={[styles.button, styles.danger]} onPress={signOut}>
-            <Text style={[styles.buttonText, styles.dangerText]}>Sign out</Text>
+            <Text style={[styles.buttonText, styles.dangerText]}>
+              {readOnly ? 'Disconnect' : 'Sign out'}
+            </Text>
           </Pressable>
         </>
       )}

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -14,10 +14,19 @@ import {
 import { Api, isUnauthorized, Settings, TokenInfo, Weekday } from '../api';
 import Header from '../components/Header';
 import Legend from '../components/Legend';
+import LocationPicker, { Coord } from '../components/LocationPicker';
 import ScheduleEditor from '../components/ScheduleEditor';
 import { MONTH_NAMES } from '../dates';
+import { disableWorkTracking, enableWorkTracking } from '../location';
 import { AttendanceState } from '../states';
-import { clearConnection, Connection } from '../storage';
+import {
+  cacheStartMonth,
+  clearConnection,
+  Connection,
+  DEFAULT_WORK_RADIUS,
+  loadWorkLocation,
+  WorkLocation,
+} from '../storage';
 import { colors, radius, spacing } from '../theme';
 
 interface Props {
@@ -54,6 +63,13 @@ export default function SettingsScreen({
   const [newSecret, setNewSecret] = useState<string | null>(null);
   const [addingAccount, setAddingAccount] = useState(false);
 
+  const [workLocation, setWorkLocation] = useState<WorkLocation | null>(null);
+  const [pickerVisible, setPickerVisible] = useState(false);
+
+  useEffect(() => {
+    loadWorkLocation().then(setWorkLocation);
+  }, []);
+
   const load = useCallback(
     async (isRefresh = false) => {
       if (isRefresh) setRefreshing(true);
@@ -63,6 +79,8 @@ export default function SettingsScreen({
         const [s, t] = await Promise.all([api.getSettings(), api.listTokens()]);
         setSettings(s);
         setTokens(t);
+        // Cache for the background geofence task, which can't fetch settings.
+        cacheStartMonth(s.trackingYearStartMonth);
       } catch (e: any) {
         setError(e?.message ?? 'Failed to load settings.');
       } finally {
@@ -97,6 +115,42 @@ export default function SettingsScreen({
       setSettings((s) => (s ? { ...s, trackingYearStartMonth: prev } : s));
       Alert.alert('Could not save', e?.message ?? 'Please try again.');
     });
+  }
+
+  async function pickWorkLocation(coord: Coord, label?: string) {
+    setPickerVisible(false);
+    const loc: WorkLocation = {
+      latitude: coord.latitude,
+      longitude: coord.longitude,
+      radius: DEFAULT_WORK_RADIUS,
+      label,
+    };
+    setWorkLocation(loc);
+    const background = await enableWorkTracking(loc);
+    if (!background) {
+      Alert.alert(
+        'Work location saved',
+        'To mark office days while the app is closed, allow "Always" location access for Officetracker in your device settings.',
+      );
+    }
+  }
+
+  function removeWorkLocation() {
+    Alert.alert(
+      'Remove work location',
+      'Stop automatically marking office days when you arrive at work?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Remove',
+          style: 'destructive',
+          onPress: async () => {
+            await disableWorkTracking();
+            setWorkLocation(null);
+          },
+        },
+      ],
+    );
   }
 
   async function addAccount() {
@@ -178,23 +232,25 @@ export default function SettingsScreen({
   }
 
   return (
-    <ScrollView
-      style={styles.flex}
-      contentContainerStyle={styles.content}
-      keyboardShouldPersistTaps="handled"
-      keyboardDismissMode="interactive"
-      automaticallyAdjustKeyboardInsets
-      refreshControl={
-        <RefreshControl
-          refreshing={refreshing}
-          onRefresh={() => load(true)}
-          tintColor={colors.textMuted}
-        />
-      }
-    >
+    <View style={styles.screen}>
+      {/* Fixed nav bar — pull-to-refresh only scrolls the content below it. */}
       <Header rightLabel="Done" onRightPress={onClose} />
 
-      <View style={styles.body}>
+      <ScrollView
+        style={styles.flex}
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="interactive"
+        automaticallyAdjustKeyboardInsets
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => load(true)}
+            tintColor={colors.textMuted}
+          />
+        }
+      >
+        <View style={styles.body}>
       <Text style={styles.screenTitle}>Settings</Text>
 
       {loading ? (
@@ -291,6 +347,51 @@ export default function SettingsScreen({
             </ScrollView>
           </View>
 
+          {/* Work location */}
+          <Text style={styles.sectionLabel}>Work location</Text>
+          <Text style={styles.hint}>
+            When you arrive here, Officetracker marks the day as an office day —
+            unless you've already set it. Days you've planned or set yourself are
+            left alone.
+          </Text>
+          <View style={styles.card}>
+            {workLocation ? (
+              <>
+                <Text style={styles.fieldLabel}>Work location</Text>
+                <Text style={styles.fieldValue}>
+                  {workLocation.label ||
+                    `${workLocation.latitude.toFixed(5)}, ${workLocation.longitude.toFixed(5)}`}
+                </Text>
+                <View style={styles.workActions}>
+                  <Pressable
+                    style={styles.workBtn}
+                    onPress={() => setPickerVisible(true)}
+                  >
+                    <Text style={styles.buttonText}>Change</Text>
+                  </Pressable>
+                  <Pressable
+                    style={[styles.workBtn, styles.workBtnDanger]}
+                    onPress={removeWorkLocation}
+                  >
+                    <Text style={[styles.buttonText, styles.dangerText]}>
+                      Remove
+                    </Text>
+                  </Pressable>
+                </View>
+              </>
+            ) : (
+              <>
+                <Text style={styles.muted}>No work location set.</Text>
+                <Pressable
+                  style={styles.button}
+                  onPress={() => setPickerVisible(true)}
+                >
+                  <Text style={styles.buttonText}>Set work location</Text>
+                </Pressable>
+              </>
+            )}
+          </View>
+
           {/* Developer tokens */}
           <Text style={styles.sectionLabel}>Developer tokens</Text>
           <Text style={styles.hint}>
@@ -362,12 +463,21 @@ export default function SettingsScreen({
           </Pressable>
         </>
       )}
-      </View>
-    </ScrollView>
+        </View>
+      </ScrollView>
+
+      <LocationPicker
+        visible={pickerVisible}
+        initial={workLocation}
+        onClose={() => setPickerVisible(false)}
+        onSelect={pickWorkLocation}
+      />
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: colors.surface },
   flex: { flex: 1, backgroundColor: colors.surface },
   content: { paddingBottom: spacing.xl * 2 },
   body: { padding: spacing.lg },
@@ -426,6 +536,16 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   buttonText: { fontSize: 15, fontWeight: '600', color: colors.text },
+  workActions: { flexDirection: 'row', gap: spacing.sm, marginTop: spacing.md },
+  workBtn: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  workBtnDanger: { borderColor: '#fecaca' },
   legendWrap: { marginTop: spacing.lg },
   tokenRow: {
     flexDirection: 'row',

--- a/mobile/src/stats.ts
+++ b/mobile/src/stats.ts
@@ -42,5 +42,6 @@ export function yearStats(year: Record<number, MonthDays>): Stats {
 }
 
 export function formatPercent(percent: number): string {
-  return `${percent.toFixed(1)}%`;
+  // Two decimals to match the web summary table.
+  return `${percent.toFixed(2)}%`;
 }

--- a/mobile/src/storage.ts
+++ b/mobile/src/storage.ts
@@ -27,3 +27,96 @@ export async function saveConnection(conn: Connection): Promise<void> {
 export async function clearConnection(): Promise<void> {
   await AsyncStorage.removeItem(KEY);
 }
+
+// ---- Work location (auto office detection) ----
+//
+// Stored only on the device: the geofencing/auto-marking feature is entirely
+// client-side, so the server never needs to know where "work" is.
+
+const WORK_LOCATION_KEY = 'officetracker.workLocation';
+const AUTO_OFFICE_KEY = 'officetracker.autoOffice';
+const START_MONTH_KEY = 'officetracker.startMonth';
+const BANNER_DISMISSED_KEY = 'officetracker.workBannerDismissed';
+
+// Default geofence radius in metres. Generous because low-accuracy GPS is fine —
+// we only care that the user got "near" work, not their exact desk.
+export const DEFAULT_WORK_RADIUS = 200;
+
+export interface WorkLocation {
+  latitude: number;
+  longitude: number;
+  // Geofence radius in metres.
+  radius: number;
+  // Human-readable label (reverse-geocoded address), for display only.
+  label?: string;
+}
+
+export async function loadWorkLocation(): Promise<WorkLocation | null> {
+  try {
+    const raw = await AsyncStorage.getItem(WORK_LOCATION_KEY);
+    if (!raw) return null;
+    const p = JSON.parse(raw) as WorkLocation;
+    if (typeof p.latitude !== 'number' || typeof p.longitude !== 'number') {
+      return null;
+    }
+    return {
+      latitude: p.latitude,
+      longitude: p.longitude,
+      radius: p.radius || DEFAULT_WORK_RADIUS,
+      label: p.label,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function saveWorkLocation(loc: WorkLocation): Promise<void> {
+  await AsyncStorage.setItem(WORK_LOCATION_KEY, JSON.stringify(loc));
+}
+
+export async function clearWorkLocation(): Promise<void> {
+  await AsyncStorage.removeItem(WORK_LOCATION_KEY);
+}
+
+// The last calendar day (YYYY-MM-DD, device-local) we resolved auto-marking for,
+// so a geofence that fires repeatedly only hits the server once per day.
+export async function getAutoOfficeHandledDate(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(AUTO_OFFICE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export async function setAutoOfficeHandledDate(date: string): Promise<void> {
+  await AsyncStorage.setItem(AUTO_OFFICE_KEY, date);
+}
+
+// The background task can't fetch settings cheaply, so the app caches the
+// tracking-year start month here whenever it loads settings.
+export async function cacheStartMonth(month: number): Promise<void> {
+  await AsyncStorage.setItem(START_MONTH_KEY, String(month));
+}
+
+export async function getCachedStartMonth(): Promise<number | null> {
+  try {
+    const raw = await AsyncStorage.getItem(START_MONTH_KEY);
+    if (!raw) return null;
+    const n = Number(raw);
+    return n >= 1 && n <= 12 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function isWorkBannerDismissed(): Promise<boolean> {
+  try {
+    return (await AsyncStorage.getItem(BANNER_DISMISSED_KEY)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export async function dismissWorkBanner(): Promise<void> {
+  await AsyncStorage.setItem(BANNER_DISMISSED_KEY, '1');
+}

--- a/mobile/src/storage.ts
+++ b/mobile/src/storage.ts
@@ -6,6 +6,9 @@ export interface Connection {
   baseUrl: string;
   // API token sent as `Authorization: Bearer <token>` (empty if the server needs no auth).
   token: string;
+  // True when the server advertised itself as read-only (see /api/v1/meta). The
+  // app then hides every write affordance and refuses mutating requests.
+  readOnly: boolean;
 }
 
 export async function loadConnection(): Promise<Connection | null> {
@@ -14,7 +17,12 @@ export async function loadConnection(): Promise<Connection | null> {
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Connection;
     if (!parsed.baseUrl) return null;
-    return { baseUrl: parsed.baseUrl, token: parsed.token ?? '' };
+    return {
+      baseUrl: parsed.baseUrl,
+      token: parsed.token ?? '',
+      // Older saved connections predate this flag — default to writable.
+      readOnly: parsed.readOnly ?? false,
+    };
   } catch {
     return null;
   }

--- a/mobile/src/theme.ts
+++ b/mobile/src/theme.ts
@@ -1,18 +1,29 @@
-// Flat design tokens, using the Officetracker brand palette
-// (see internal/embed/html/hero.html + bases/base.html).
+// Design tokens mirroring the Officetracker web app so the two clients feel
+// like one product. Values are taken straight from the web stylesheet
+// (internal/embed/html/bases/base.html + static/themes.css): an off-white page,
+// a white content card, a pale-cyan nav bar, square-ish borders and a charcoal
+// brand accent.
 export const colors = {
-  bg: '#ffffff',
-  surface: '#ffffff',
-  border: '#e5e7eb',
-  borderStrong: '#d1d5db',
-  text: '#384346', // brand slate (hero body text)
-  textMuted: '#526064', // brand muted slate
-  textFaint: '#9ca3af',
-  accent: '#24292e', // brand charcoal (primary buttons / wordmark)
-  brandTint: '#eef8f6', // brand mint (hero background)
-  danger: '#dc2626',
-  fieldBg: '#f9fafb',
-  todayRing: '#FFC107', // amber, matches the web app's "today" border
+  // Page + surfaces
+  bg: '#f7f8f8', // web body background
+  surface: '#ffffff', // white content card (web <main>)
+  navBg: '#ddeeee', // web nav bar (`#dee`)
+  border: '#dee2e6', // web border colour, used everywhere
+  borderStrong: '#adb5bd', // dashed "planned" outlines
+  cellBg: '#f8f9fa', // web weekday-header / day background
+  fieldBg: '#f8f9fa', // inputs + notes textarea
+  tableHeaderBg: '#f4f4f4', // web summary table header
+
+  // Text
+  text: '#212529', // headings / primary text
+  textMuted: '#495057', // web secondary text colour
+  textFaint: '#6c757d', // faint labels, hints, footer
+
+  // Brand + status
+  accent: '#24292e', // brand charcoal (buttons / wordmark)
+  brandTint: '#eef8f6', // hero mint (login background)
+  danger: '#F44336', // web red (.not-present)
+  todayRing: '#FFC107', // web "today" amber border
 };
 
 // "Officetracker" wordmark font (Google Calistoga), loaded at runtime in App.tsx.
@@ -28,8 +39,9 @@ export const spacing = {
   xl: 24,
 };
 
+// The web app uses a consistent 4px corner radius; keep it subtle and flat.
 export const radius = {
-  sm: 6,
-  md: 8,
-  lg: 12,
+  sm: 4,
+  md: 4,
+  lg: 6,
 };


### PR DESCRIPTION
## 📱 Officetracker is coming to iOS _and_ Android

I'm looking for some beta testers before it goes live.

If you're interested, email [contact@officetracker.com.au](mailto:contact@officetracker.com.au) with the email on your Apple ID or Google Account, and I'll send you a **TestFlight** or **Play Store** invite.

Feedback welcome 🙏

---

The accumulated `mobile-dev` work, bringing the native app up to parity with the web app and adding several new capabilities. Grouped by area below.

## 1. Redesign to match the web app (visual)
Beta testers said the app looked AI-generated and unlike the web UI. Restyled the client to mirror the Officetracker web app so the two read as one product:
- Shared pale-cyan nav bar with the Calistoga wordmark (new shared `Header`).
- Web palette: off-white page, white content card, web borders/colours, flat 4px radii.
- Summary is now the web's bordered Month/Present/Total/Percent table (not stat cards).
- Square legend swatches; plain-text weekday headers; web-style section headings.
- Swipe left/right on the calendar to change months.

## 2. Auth + session flow (behavioural)
- Login runs in an iOS ephemeral web session with `prompt=login`, so signing in always shows the Auth0 login screen instead of silently reusing a cached SSO session — previously you could never actually switch account.
- Removed "Sign in again" and the server field from Settings, and the dead relogin screen. Switching server/account is done by signing out → "Use a different server" on the login screen.
- The login screen presents a picker of known servers (officetracker.com.au default, plus beta.officetracker.com.au and officetracker.baileys.app), with an "Enter a different server…" row that reveals the manual URL field for custom/anonymous instances. The picker stays hidden behind "Use a different server" until tapped.

## 3. Automatic office detection from a work location
Opt-in feature that marks a day as "office" automatically when the user arrives near a saved work location.
- Settings gains a "Work location" card to set, change or remove the location. Input is by address search or by dropping a pin on a map — a native Apple Maps `MapView` on iOS, and a key-free Leaflet/OpenStreetMap WebView on Android (no map API key needed on either).
- A geofence (`expo-location` + `expo-task-manager`) marks today as Office on arrival, even when the app is backgrounded or closed. A foreground proximity check on launch covers opening the app while already at work. Days the user set themselves (or that are only planned) are left untouched, and the server is updated at most once per day.
- The work location is stored only on the device; no backend changes.
- A dismissible home-screen banner prompts users to set their work location.

## 4. Anonymous read-only server support
- Probes a new `GET /api/v1/meta` capability endpoint on connect. `auth:"none"` skips the Auth0 sign-in + `/auth/native` token exchange and connects with an empty token; `read_only:true` locks the UI to read-only (disables day cycling/note editing, hides the work-location banner and the Accounts / Work location / Developer tokens settings, turns Sign out into Disconnect). Mutating requests are also refused client-side in the `Api` layer as a safeguard.
- A read-only server is rendered identically to a normal writable one (no "demo" wording, same tip, Notes field always shown but disabled) — writes are just silently disabled.
- Servers without `/api/v1/meta` fall back to the historical default (Auth0 + writable), so existing instances are unaffected.

## 5. CI/CD — EAS build workflow
- New `mobile-eas-build.yaml`: cloud builds on Expo Application Services. Manual `workflow_dispatch` with platform/profile/submit inputs.
- Push builds are restricted to version tags (`v*`) — ordinary commits no longer trigger a build — and auto-submit both iOS (TestFlight) and Android (Play Store internal track) on tag push.
- App Store Connect submission configured (`ascAppId` under `submit.production.ios`, `ITSAppUsesNonExemptEncryption: false` to avoid export-compliance holds); Android package + submit profile added.
- Requires an `EXPO_TOKEN` repo secret.

## 6. Easter egg
Seven quick taps on the "Officetracker" wordmark fetches the live status from isbaileybutlerintheoffice.today/raw and shows the real Yes/No in an alert. Lives in the shared `Header`, so it's reachable from both screens; taps reset after 1.5s and a failed fetch degrades quietly.

## Testing
- `tsc --noEmit` passes.
- Run on the iOS simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
