### PR TITLE
Add anonymous read-only server support to the mobile app

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -48,8 +48,32 @@ calls. The token shows up on the server's Developer page as
 
 By default it connects to `https://officetracker.com.au`. Tap **Use a different
 server** on the login screen to point at another instance (e.g.
-`https://beta.officetracker.com.au`) — note it still authenticates against the
-same Auth0 tenant.
+`https://beta.officetracker.com.au`) — for an Auth0-backed instance it still
+authenticates against the same Auth0 tenant.
+
+### Server capabilities (`/api/v1/meta`)
+
+When connecting, the app probes `GET /api/v1/meta` to learn how to talk to the
+server. The response is JSON:
+
+```json
+{ "auth": "auth0", "read_only": false }
+```
+
+- `auth`: `"auth0"` (default) means do the Auth0 sign-in + `POST /auth/native`
+  token exchange described above. `"none"` means the server is **anonymous** —
+  the app skips Auth0 entirely and connects with no token (the **Sign in**
+  button becomes **Continue**).
+- `read_only`: when `true`, the app locks the whole UI to **read-only** —
+  attendance days and notes can be browsed but not edited, the work-location
+  prompt is hidden, and the account / work-location / developer-token sections of
+  Settings are hidden (sign-out becomes **Disconnect**). Mutating requests are
+  also refused client-side as a safeguard.
+
+Servers that don't implement `/api/v1/meta` (HTTP 404, or unreachable) fall back
+to the historical default — `auth0` and writable — so existing instances keep
+working unchanged. A public demo instance ("demotracker") would serve
+`{ "auth": "none", "read_only": true }`.
 
 ## Auth0 configuration
 

--- a/mobile/src/api.ts
+++ b/mobile/src/api.ts
@@ -89,6 +89,39 @@ async function rawFetch(url: string, init?: RequestInit): Promise<Response> {
   }
 }
 
+// How a server expects clients to authenticate. 'none' means the server serves
+// anonymous requests with no token (e.g. a public demo instance).
+export type ServerAuth = 'auth0' | 'none';
+
+export interface ServerMeta {
+  // Authentication scheme the server expects.
+  auth: ServerAuth;
+  // When true the server rejects all writes; the app locks its UI to read-only.
+  readOnly: boolean;
+}
+
+// Probes a server's capabilities via GET /api/v1/meta. Servers that predate the
+// endpoint (or that can't be reached) fall back to the historical default —
+// Auth0 sign-in and a writable instance — so existing instances keep working.
+export async function fetchServerMeta(baseUrl: string): Promise<ServerMeta> {
+  try {
+    const res = await rawFetch(`${normaliseBase(baseUrl)}/api/v1/meta`);
+    if (!res.ok) return { auth: 'auth0', readOnly: false };
+    const body = (await res.json()) as {
+      auth?: string;
+      // Accept both the Go snake_case wire form and a camelCase fallback.
+      read_only?: boolean;
+      readOnly?: boolean;
+    };
+    return {
+      auth: body.auth === 'none' ? 'none' : 'auth0',
+      readOnly: !!(body.read_only ?? body.readOnly),
+    };
+  } catch {
+    return { auth: 'auth0', readOnly: false };
+  }
+}
+
 // Exchanges an Auth0 ID token (obtained natively via react-native-auth0) for a
 // long-lived Office Tracker API token. See the server's /auth/native handler.
 export async function exchangeNativeToken(
@@ -132,6 +165,12 @@ export class Api {
   }
 
   private async request(path: string, init?: RequestInit): Promise<Response> {
+    // Defence in depth: the UI hides writes on a read-only server, but never let
+    // a mutating request leave the device regardless of which code path calls in.
+    const method = (init?.method ?? 'GET').toUpperCase();
+    if (this.conn.readOnly && method !== 'GET') {
+      throw new ApiError('This server is read-only.', 405);
+    }
     const res = await rawFetch(this.url(path), init);
     if (res.status === 401 || res.status === 403) {
       // Token expired or revoked — trigger a sign-out.

--- a/mobile/src/components/Calendar.tsx
+++ b/mobile/src/components/Calendar.tsx
@@ -11,9 +11,11 @@ interface Props {
   month: number; // 1-12
   days: MonthDays;
   onCycle: (day: number, direction: 1 | -1) => void;
+  // Display-only: render days without responding to taps (read-only server).
+  readOnly?: boolean;
 }
 
-function Calendar({ year, month, days, onCycle }: Props) {
+function Calendar({ year, month, days, onCycle, readOnly }: Props) {
   const weeks = monthGrid(year, month);
 
   return (
@@ -39,6 +41,7 @@ function Calendar({ year, month, days, onCycle }: Props) {
               }
               onPress={() => cell.day != null && onCycle(cell.day, 1)}
               onLongPress={() => cell.day != null && onCycle(cell.day, -1)}
+              disabled={readOnly}
             />
           ))}
         </View>

--- a/mobile/src/components/DayCell.tsx
+++ b/mobile/src/components/DayCell.tsx
@@ -9,9 +9,11 @@ interface Props {
   isToday: boolean;
   onPress: () => void;
   onLongPress: () => void;
+  // Display-only: render the day without responding to taps (read-only server).
+  disabled?: boolean;
 }
 
-function DayCell({ day, state, isToday, onPress, onLongPress }: Props) {
+function DayCell({ day, state, isToday, onPress, onLongPress, disabled }: Props) {
   if (day === null) {
     return <View style={styles.cell} />;
   }
@@ -25,12 +27,13 @@ function DayCell({ day, state, isToday, onPress, onLongPress }: Props) {
         onPress={onPress}
         onLongPress={onLongPress}
         delayLongPress={250}
+        disabled={disabled}
         style={({ pressed }) => [
           styles.day,
           filled && { backgroundColor: look.bg },
           look.scheduled && styles.scheduled,
           isToday && styles.today,
-          pressed && styles.pressed,
+          pressed && !disabled && styles.pressed,
         ]}
       >
         <Text

--- a/mobile/src/components/ScheduleEditor.tsx
+++ b/mobile/src/components/ScheduleEditor.tsx
@@ -17,9 +17,11 @@ const LABELS: Record<Weekday, string> = {
 interface Props {
   schedule: SchedulePreferences;
   onChange: (day: Weekday, next: AttendanceState) => void;
+  // Display-only: render the schedule without responding to taps (read-only server).
+  disabled?: boolean;
 }
 
-export default function ScheduleEditor({ schedule, onChange }: Props) {
+export default function ScheduleEditor({ schedule, onChange, disabled }: Props) {
   return (
     <View style={styles.row}>
       {WEEKDAYS_LOWER.map((day) => {
@@ -33,10 +35,11 @@ export default function ScheduleEditor({ schedule, onChange }: Props) {
               onPress={() => onChange(day, cycleState(state, 1))}
               onLongPress={() => onChange(day, cycleState(state, -1))}
               delayLongPress={250}
+              disabled={disabled}
               style={({ pressed }) => [
                 styles.cell,
                 filled && { backgroundColor: look.bg },
-                pressed && styles.pressed,
+                pressed && !disabled && styles.pressed,
               ]}
             />
           </View>

--- a/mobile/src/screens/CalendarScreen.tsx
+++ b/mobile/src/screens/CalendarScreen.tsx
@@ -58,6 +58,9 @@ export default function CalendarScreen({
     [conn, onUnauthorized],
   );
 
+  // Read-only servers (e.g. the public demo) can be browsed but never written to.
+  const readOnly = conn.readOnly;
+
   const [view, setView] = useState<ViewMonth>(thisMonth());
   const [startMonth, setStartMonth] = useState(DEFAULT_TRACKING_YEAR_START_MONTH);
   const fy = trackingYear(view.year, view.month, startMonth);
@@ -178,6 +181,7 @@ export default function CalendarScreen({
 
   const onCycle = useCallback(
     (day: number, direction: 1 | -1) => {
+      if (readOnly) return;
       // Read the live value so rapid taps don't cycle/revert from a stale closure.
       const current =
         yearDataRef.current[view.month]?.[day] ?? AttendanceState.Untracked;
@@ -215,10 +219,11 @@ export default function CalendarScreen({
           }
         });
     },
-    [api, view, fy],
+    [api, view, fy, readOnly],
   );
 
   const saveNote = useCallback(() => {
+    if (readOnly) return;
     const text = noteText;
     const prev = notes[view.month] ?? '';
     if (prev === text) return;
@@ -228,7 +233,7 @@ export default function CalendarScreen({
       setNotes((n) => ({ ...n, [view.month]: prev })); // revert on failure
       Alert.alert('Could not save note', e?.message ?? 'Please try again.');
     });
-  }, [api, noteText, notes, view]);
+  }, [api, noteText, notes, view, readOnly]);
 
   // Save any pending note before leaving the current month/screen.
   const go = (delta: number) => {
@@ -301,7 +306,7 @@ export default function CalendarScreen({
         }
       >
         <View style={styles.body}>
-        {showBanner && (
+        {showBanner && !readOnly && (
           <WorkLocationBanner
             onPress={() => setPickerVisible(true)}
             onDismiss={dismissBanner}
@@ -348,30 +353,40 @@ export default function CalendarScreen({
               month={view.month}
               days={days}
               onCycle={onCycle}
+              readOnly={readOnly}
             />
           </View>
 
           <Text style={styles.tip}>
-            Tap a day to cycle through home, office and other; long-press to go
-            back.
+            {readOnly
+              ? 'This is a read-only demo — attendance is shown but cannot be edited.'
+              : 'Tap a day to cycle through home, office and other; long-press to go back.'}
           </Text>
           <View style={styles.legendWrap}>
             <Legend />
           </View>
 
-          <View style={styles.section}>
-            <Text style={styles.heading}>Notes</Text>
-            <TextInput
-              style={styles.notes}
-              value={noteText}
-              onChangeText={setNoteText}
-              onBlur={saveNote}
-              placeholder={`Notes for ${formatMonthYear(view)}…`}
-              placeholderTextColor={colors.textFaint}
-              multiline
-              textAlignVertical="top"
-            />
-          </View>
+          {(!readOnly || noteText) && (
+            <View style={styles.section}>
+              <Text style={styles.heading}>Notes</Text>
+              {readOnly ? (
+                <Text style={[styles.notes, styles.notesReadOnly]}>
+                  {noteText}
+                </Text>
+              ) : (
+                <TextInput
+                  style={styles.notes}
+                  value={noteText}
+                  onChangeText={setNoteText}
+                  onBlur={saveNote}
+                  placeholder={`Notes for ${formatMonthYear(view)}…`}
+                  placeholderTextColor={colors.textFaint}
+                  multiline
+                  textAlignVertical="top"
+                />
+              )}
+            </View>
+          )}
 
           <View style={styles.section}>
             <Text style={styles.heading}>Summary</Text>
@@ -483,5 +498,8 @@ const styles = StyleSheet.create({
     color: colors.text,
     backgroundColor: colors.fieldBg,
     lineHeight: 21,
+  },
+  notesReadOnly: {
+    color: colors.textMuted,
   },
 });

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -11,7 +11,7 @@ import {
   View,
 } from 'react-native';
 import { useAuth0 } from 'react-native-auth0';
-import { exchangeNativeToken } from '../api';
+import { exchangeNativeToken, fetchServerMeta, ServerMeta } from '../api';
 import { AUTH0_SCHEME, DEFAULT_BASE_URL } from '../config';
 import { Connection, saveConnection } from '../storage';
 import { colors, fonts, radius, spacing } from '../theme';
@@ -38,13 +38,40 @@ export default function LoginScreen({
   const [advanced, setAdvanced] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Cached capabilities of the entered server, probed when the field changes so
+  // we can relabel the button and hint that no sign-in is needed.
+  const [serverMeta, setServerMeta] = useState<ServerMeta | null>(null);
 
   const normalised = normaliseUrl(baseUrl);
+  const anonymous = serverMeta?.auth === 'none';
 
-  async function signIn() {
+  // Probe the server's /api/v1/meta so the UI reflects an anonymous server
+  // before the user commits. Runs on blur of the server field.
+  async function probeServer() {
+    setServerMeta(await fetchServerMeta(normaliseUrl(baseUrl)));
+  }
+
+  async function connect() {
     setError(null);
     setBusy(true);
     try {
+      // Ask the server how to authenticate (cheap, unauthenticated probe).
+      const meta = await fetchServerMeta(normalised);
+      setServerMeta(meta);
+
+      // Anonymous server: no Auth0 prompt and no token exchange — connect with
+      // an empty token straight away.
+      if (meta.auth === 'none') {
+        const conn: Connection = {
+          baseUrl: normalised,
+          token: '',
+          readOnly: meta.readOnly,
+        };
+        await saveConnection(conn);
+        onConnected(conn);
+        return;
+      }
+
       const credentials = await authorize(
         // Always show a fresh login screen instead of silently reusing a cached
         // Auth0 session. prompt=login asks the server to re-prompt, and
@@ -64,7 +91,11 @@ export default function LoginScreen({
       }
 
       const token = await exchangeNativeToken(normalised, credentials.idToken);
-      const conn: Connection = { baseUrl: normalised, token };
+      const conn: Connection = {
+        baseUrl: normalised,
+        token,
+        readOnly: meta.readOnly,
+      };
       await saveConnection(conn);
       onConnected(conn);
     } catch (e: any) {
@@ -100,13 +131,15 @@ export default function LoginScreen({
               pressed && styles.buttonPressed,
               busy && styles.buttonDisabled,
             ]}
-            onPress={signIn}
+            onPress={connect}
             disabled={busy}
           >
             {busy ? (
               <ActivityIndicator color="#ffffff" />
             ) : (
-              <Text style={styles.buttonText}>Sign in</Text>
+              <Text style={styles.buttonText}>
+                {anonymous ? 'Continue' : 'Sign in'}
+              </Text>
             )}
           </Pressable>
 
@@ -116,7 +149,12 @@ export default function LoginScreen({
               <TextInput
                 style={styles.input}
                 value={baseUrl}
-                onChangeText={setBaseUrl}
+                onChangeText={(t) => {
+                  setBaseUrl(t);
+                  // A new URL invalidates the previous probe.
+                  setServerMeta(null);
+                }}
+                onBlur={probeServer}
                 autoCapitalize="none"
                 autoCorrect={false}
                 keyboardType="url"
@@ -126,7 +164,9 @@ export default function LoginScreen({
                 editable={!busy}
               />
               <Text style={styles.hint}>
-                Change this only if you use a different Office Tracker instance.
+                {anonymous
+                  ? "This server doesn't require sign in — it's a read-only demo."
+                  : 'Change this only if you use a different Office Tracker instance.'}
               </Text>
             </View>
           ) : (

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -52,6 +52,9 @@ export default function SettingsScreen({
     [conn, onUnauthorized],
   );
 
+  // Read-only servers (e.g. the public demo) hide every account/write affordance.
+  const readOnly = conn.readOnly;
+
   const [settings, setSettings] = useState<Settings | null>(null);
   const [tokens, setTokens] = useState<TokenInfo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -76,7 +79,12 @@ export default function SettingsScreen({
       else setLoading(true);
       setError(null);
       try {
-        const [s, t] = await Promise.all([api.getSettings(), api.listTokens()]);
+        // Developer tokens require auth; skip them on a read-only/anonymous
+        // server (the section is hidden, and the call would otherwise 401).
+        const [s, t] = await Promise.all([
+          api.getSettings(),
+          readOnly ? Promise.resolve<TokenInfo[]>([]) : api.listTokens(),
+        ]);
         setSettings(s);
         setTokens(t);
         // Cache for the background geofence task, which can't fetch settings.
@@ -88,7 +96,7 @@ export default function SettingsScreen({
         setRefreshing(false);
       }
     },
-    [api],
+    [api, readOnly],
   );
 
   useEffect(() => {
@@ -217,6 +225,21 @@ export default function SettingsScreen({
   }
 
   function signOut() {
+    // A read-only/anonymous connection has no session to revoke — just drop it.
+    if (readOnly) {
+      Alert.alert('Disconnect', 'Disconnect from this server?', [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Disconnect',
+          style: 'destructive',
+          onPress: async () => {
+            await clearConnection();
+            onDisconnect();
+          },
+        },
+      ]);
+      return;
+    }
     Alert.alert('Sign out', 'Sign out of Officetracker on this device?', [
       { text: 'Cancel', style: 'cancel' },
       {
@@ -266,44 +289,50 @@ export default function SettingsScreen({
         </View>
       ) : (
         <>
-          {/* Accounts */}
-          <Text style={styles.sectionLabel}>Accounts</Text>
-          <View style={styles.card}>
-            {settings && settings.linkedAccounts.length > 0 ? (
-              settings.linkedAccounts.map((a, i) => (
-                <View key={`${a.provider}-${i}`}>
-                  {i > 0 && <View style={styles.hr} />}
-                  <Text style={styles.fieldLabel}>{a.providerDisplay}</Text>
-                  <Text style={styles.fieldValue}>{a.nickname || '—'}</Text>
-                </View>
-              ))
-            ) : (
-              <Text style={styles.muted}>No linked accounts.</Text>
-            )}
-          </View>
-          <Pressable
-            style={styles.button}
-            onPress={addAccount}
-            disabled={addingAccount}
-          >
-            {addingAccount ? (
-              <ActivityIndicator color={colors.text} />
-            ) : (
-              <Text style={styles.buttonText}>Add account</Text>
-            )}
-          </Pressable>
+          {/* Accounts (hidden on a read-only/anonymous server) */}
+          {!readOnly && (
+            <>
+              <Text style={styles.sectionLabel}>Accounts</Text>
+              <View style={styles.card}>
+                {settings && settings.linkedAccounts.length > 0 ? (
+                  settings.linkedAccounts.map((a, i) => (
+                    <View key={`${a.provider}-${i}`}>
+                      {i > 0 && <View style={styles.hr} />}
+                      <Text style={styles.fieldLabel}>{a.providerDisplay}</Text>
+                      <Text style={styles.fieldValue}>{a.nickname || '—'}</Text>
+                    </View>
+                  ))
+                ) : (
+                  <Text style={styles.muted}>No linked accounts.</Text>
+                )}
+              </View>
+              <Pressable
+                style={styles.button}
+                onPress={addAccount}
+                disabled={addingAccount}
+              >
+                {addingAccount ? (
+                  <ActivityIndicator color={colors.text} />
+                ) : (
+                  <Text style={styles.buttonText}>Add account</Text>
+                )}
+              </Pressable>
+            </>
+          )}
 
           {/* Planned days */}
           <Text style={styles.sectionLabel}>Planned days</Text>
           <Text style={styles.hint}>
-            Set the days you usually attend. They show as faded "planned" days on
-            the calendar. Tap to cycle, long-press to go back.
+            {readOnly
+              ? 'The days usually attended, shown as faded "planned" days on the calendar.'
+              : 'Set the days you usually attend. They show as faded "planned" days on the calendar. Tap to cycle, long-press to go back.'}
           </Text>
           <View style={styles.card}>
             {settings && (
               <ScheduleEditor
                 schedule={settings.schedule}
                 onChange={cycleSchedule}
+                disabled={readOnly}
               />
             )}
             <View style={styles.legendWrap}>
@@ -331,6 +360,7 @@ export default function SettingsScreen({
                   <Pressable
                     key={month}
                     onPress={() => setTrackingStart(month)}
+                    disabled={readOnly}
                     style={[styles.monthChip, selected && styles.monthChipSelected]}
                   >
                     <Text
@@ -347,7 +377,9 @@ export default function SettingsScreen({
             </ScrollView>
           </View>
 
-          {/* Work location */}
+          {/* Work location (device feature; hidden on a read-only server) */}
+          {!readOnly && (
+            <>
           <Text style={styles.sectionLabel}>Work location</Text>
           <Text style={styles.hint}>
             When you arrive here, Officetracker marks the day as an office day —
@@ -391,8 +423,12 @@ export default function SettingsScreen({
               </>
             )}
           </View>
+            </>
+          )}
 
-          {/* Developer tokens */}
+          {/* Developer tokens (require auth; hidden on a read-only server) */}
+          {!readOnly && (
+            <>
           <Text style={styles.sectionLabel}>Developer tokens</Text>
           <Text style={styles.hint}>
             API tokens for scripts or the MCP server. Sent as a Bearer token.
@@ -457,9 +493,13 @@ export default function SettingsScreen({
               </Pressable>
             </View>
           )}
+            </>
+          )}
 
           <Pressable style={[styles.button, styles.danger]} onPress={signOut}>
-            <Text style={[styles.buttonText, styles.dangerText]}>Sign out</Text>
+            <Text style={[styles.buttonText, styles.dangerText]}>
+              {readOnly ? 'Disconnect' : 'Sign out'}
+            </Text>
           </Pressable>
         </>
       )}

--- a/mobile/src/storage.ts
+++ b/mobile/src/storage.ts
@@ -6,6 +6,9 @@ export interface Connection {
   baseUrl: string;
   // API token sent as `Authorization: Bearer <token>` (empty if the server needs no auth).
   token: string;
+  // True when the server advertised itself as read-only (see /api/v1/meta). The
+  // app then hides every write affordance and refuses mutating requests.
+  readOnly: boolean;
 }
 
 export async function loadConnection(): Promise<Connection | null> {
@@ -14,7 +17,12 @@ export async function loadConnection(): Promise<Connection | null> {
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Connection;
     if (!parsed.baseUrl) return null;
-    return { baseUrl: parsed.baseUrl, token: parsed.token ?? '' };
+    return {
+      baseUrl: parsed.baseUrl,
+      token: parsed.token ?? '',
+      // Older saved connections predate this flag — default to writable.
+      readOnly: parsed.readOnly ?? false,
+    };
   } catch {
     return null;
   }


### PR DESCRIPTION
## What

Lets the mobile app connect to an **anonymous, read-only** Office Tracker server (e.g. a public `demotracker` instance) — no Auth0 login, no writes.

The app probes a new capability endpoint when connecting:

```
GET /api/v1/meta → { "auth": "none" | "auth0", "read_only": true }
```

- **`auth: "none"`** → skip the Auth0 sign-in and `POST /auth/native` token exchange entirely; connect with an empty token. The **Sign in** button becomes **Continue**.
- **`read_only: true`** → lock the whole UI:
  - calendar day cycling and note editing disabled (notes shown as read-only text),
  - work-location banner hidden,
  - Settings hides the **Accounts**, **Work location**, and **Developer tokens** sections,
  - **Sign out** becomes **Disconnect** (no session to revoke),
  - mutating requests are also refused in the `Api` layer as defense-in-depth.

Servers that don't implement `/api/v1/meta` (404 / unreachable) fall back to the historical default — Auth0 + writable — so existing instances are unaffected.

## Scope

Mobile client only. A `demotracker` server just needs to serve `{ "auth": "none", "read_only": true }` from `/api/v1/meta`. The health check (`/api/v1/health/check`) is left as a pure liveness probe.

## Notes

- Files changed: `api.ts`, `storage.ts`, `LoginScreen.tsx`, `CalendarScreen.tsx`, `SettingsScreen.tsx`, `Calendar.tsx`, `DayCell.tsx`, `ScheduleEditor.tsx`, plus README docs.
- `tsc --noEmit` is clean for all changed files (pre-existing errors in `LocationPicker.tsx`/`location.ts` are due to a few packages not being installed in this checkout, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)