### PR TITLE
Known-server picker on the login screen

### DIFF
--- a/mobile/src/config.ts
+++ b/mobile/src/config.ts
@@ -1,6 +1,21 @@
 // Default server; users can point elsewhere from the login screen.
 export const DEFAULT_BASE_URL = 'https://officetracker.com.au';
 
+export interface KnownServer {
+  // Shown in the login server picker.
+  label: string;
+  // Base URL connected to (no trailing slash).
+  url: string;
+}
+
+// Servers offered on the login screen. The first entry is the default and must
+// match DEFAULT_BASE_URL. Users can still enter any other instance manually.
+export const KNOWN_SERVERS: KnownServer[] = [
+  { label: 'officetracker.com.au', url: 'https://officetracker.com.au' },
+  { label: 'beta.officetracker.com.au', url: 'https://beta.officetracker.com.au' },
+  { label: 'officetracker.baileys.app', url: 'https://officetracker.baileys.app' },
+];
+
 // Native Auth0 application (react-native-auth0). Client ID is public.
 export const AUTH0_DOMAIN = 'auth.officetracker.com.au';
 export const AUTH0_CLIENT_ID = 'i7HP3uXeIm0ItFiqXRprnRYmU6bJCI6S';

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-native';
 import { useAuth0 } from 'react-native-auth0';
 import { exchangeNativeToken, fetchServerMeta, ServerMeta } from '../api';
-import { AUTH0_SCHEME, DEFAULT_BASE_URL } from '../config';
+import { AUTH0_SCHEME, DEFAULT_BASE_URL, KNOWN_SERVERS } from '../config';
 import { Connection, saveConnection } from '../storage';
 import { colors, fonts, radius, spacing } from '../theme';
 
@@ -35,20 +35,34 @@ export default function LoginScreen({
 }: Props) {
   const { authorize } = useAuth0();
   const [baseUrl, setBaseUrl] = useState(initialBaseUrl ?? DEFAULT_BASE_URL);
-  const [advanced, setAdvanced] = useState(false);
+  // Manual entry is for instances not in the known list. Start in manual mode
+  // only when resuming with a previously-used server that isn't a known one.
+  const [manual, setManual] = useState(
+    () =>
+      !!initialBaseUrl &&
+      !KNOWN_SERVERS.some((s) => s.url === normaliseUrl(initialBaseUrl)),
+  );
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Cached capabilities of the entered server, probed when the field changes so
-  // we can relabel the button and hint that no sign-in is needed.
+  // Cached capabilities of the chosen server, probed when the selection changes
+  // so we can relabel the button and hint that no sign-in is needed.
   const [serverMeta, setServerMeta] = useState<ServerMeta | null>(null);
 
   const normalised = normaliseUrl(baseUrl);
   const anonymous = serverMeta?.auth === 'none';
 
-  // Probe the server's /api/v1/meta so the UI reflects an anonymous server
-  // before the user commits. Runs on blur of the server field.
-  async function probeServer() {
-    setServerMeta(await fetchServerMeta(normaliseUrl(baseUrl)));
+  // Probe a server's /api/v1/meta so the UI reflects an anonymous server before
+  // the user commits. Runs when a list item is picked, or on blur of the field.
+  async function probeServer(url: string = baseUrl) {
+    setServerMeta(await fetchServerMeta(normaliseUrl(url)));
+  }
+
+  // Pick one of the known servers.
+  function selectServer(url: string) {
+    setManual(false);
+    setBaseUrl(url);
+    setServerMeta(null);
+    probeServer(url);
   }
 
   async function connect() {
@@ -125,14 +139,92 @@ export default function LoginScreen({
         <View style={styles.actions}>
           {error && <Text style={styles.error}>{error}</Text>}
 
+          {/* Server picker — choose a known instance, or enter one manually. */}
+          <Text style={styles.label}>Server</Text>
+          <View style={styles.serverList}>
+            {KNOWN_SERVERS.map((s) => {
+              const selected = !manual && normalised === s.url;
+              return (
+                <Pressable
+                  key={s.url}
+                  onPress={() => selectServer(s.url)}
+                  disabled={busy}
+                  style={({ pressed }) => [
+                    styles.serverRow,
+                    selected && styles.serverRowSelected,
+                    pressed && styles.serverRowPressed,
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.serverLabel,
+                      selected && styles.serverLabelSelected,
+                    ]}
+                  >
+                    {s.label}
+                  </Text>
+                  {selected && <Text style={styles.check}>✓</Text>}
+                </Pressable>
+              );
+            })}
+            <Pressable
+              onPress={() => {
+                setManual(true);
+                setBaseUrl('');
+                setServerMeta(null);
+              }}
+              disabled={busy}
+              style={({ pressed }) => [
+                styles.serverRow,
+                manual && styles.serverRowSelected,
+                pressed && styles.serverRowPressed,
+              ]}
+            >
+              <Text
+                style={[styles.serverLabel, manual && styles.serverLabelSelected]}
+              >
+                Enter a different server…
+              </Text>
+              {manual && <Text style={styles.check}>✓</Text>}
+            </Pressable>
+          </View>
+
+          {manual && (
+            <TextInput
+              style={styles.input}
+              value={baseUrl}
+              onChangeText={(t) => {
+                setBaseUrl(t);
+                // A new URL invalidates the previous probe.
+                setServerMeta(null);
+              }}
+              onBlur={() => probeServer()}
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoFocus
+              keyboardType="url"
+              inputMode="url"
+              placeholder={DEFAULT_BASE_URL}
+              placeholderTextColor={colors.textFaint}
+              editable={!busy}
+            />
+          )}
+
+          {anonymous && (
+            <Text style={styles.hint}>
+              This server doesn&apos;t require sign in — it&apos;s a read-only
+              demo.
+            </Text>
+          )}
+
           <Pressable
             style={({ pressed }) => [
               styles.button,
               pressed && styles.buttonPressed,
-              busy && styles.buttonDisabled,
+              (busy || (manual && !baseUrl.trim())) && styles.buttonDisabled,
             ]}
             onPress={connect}
-            disabled={busy}
+            disabled={busy || (manual && !baseUrl.trim())}
           >
             {busy ? (
               <ActivityIndicator color="#ffffff" />
@@ -142,38 +234,6 @@ export default function LoginScreen({
               </Text>
             )}
           </Pressable>
-
-          {advanced ? (
-            <View style={styles.advanced}>
-              <Text style={styles.label}>Server</Text>
-              <TextInput
-                style={styles.input}
-                value={baseUrl}
-                onChangeText={(t) => {
-                  setBaseUrl(t);
-                  // A new URL invalidates the previous probe.
-                  setServerMeta(null);
-                }}
-                onBlur={probeServer}
-                autoCapitalize="none"
-                autoCorrect={false}
-                keyboardType="url"
-                inputMode="url"
-                placeholder={DEFAULT_BASE_URL}
-                placeholderTextColor={colors.textFaint}
-                editable={!busy}
-              />
-              <Text style={styles.hint}>
-                {anonymous
-                  ? "This server doesn't require sign in — it's a read-only demo."
-                  : 'Change this only if you use a different Office Tracker instance.'}
-              </Text>
-            </View>
-          ) : (
-            <Pressable onPress={() => setAdvanced(true)} hitSlop={8} disabled={busy}>
-              <Text style={styles.advancedLink}>Use a different server</Text>
-            </Pressable>
-          )}
 
           {onCancel && (
             <Pressable style={styles.cancel} onPress={onCancel} disabled={busy}>
@@ -226,6 +286,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   button: {
+    marginTop: spacing.lg,
     backgroundColor: colors.accent,
     borderRadius: radius.md,
     paddingVertical: spacing.md + 2,
@@ -234,20 +295,36 @@ const styles = StyleSheet.create({
   buttonPressed: { opacity: 0.8 },
   buttonDisabled: { opacity: 0.6 },
   buttonText: { color: '#ffffff', fontSize: 16, fontWeight: '600' },
-  advancedLink: {
-    marginTop: spacing.lg,
-    textAlign: 'center',
-    color: colors.textMuted,
-    fontSize: 14,
-  },
-  advanced: { marginTop: spacing.lg },
   label: {
     fontSize: 13,
     fontWeight: '600',
     color: colors.text,
-    marginBottom: spacing.xs,
+    marginBottom: spacing.sm,
   },
+  serverList: {
+    gap: spacing.sm,
+  },
+  serverRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.md,
+    backgroundColor: colors.fieldBg,
+  },
+  serverRowSelected: {
+    borderColor: colors.accent,
+    backgroundColor: colors.brandTint,
+  },
+  serverRowPressed: { opacity: 0.6 },
+  serverLabel: { fontSize: 15, color: colors.text },
+  serverLabelSelected: { fontWeight: '700', color: colors.accent },
+  check: { fontSize: 16, fontWeight: '700', color: colors.accent },
   input: {
+    marginTop: spacing.sm,
     borderWidth: 1,
     borderColor: colors.border,
     borderRadius: radius.md,


### PR DESCRIPTION
## What

Replaces the free-text "Use a different server" field on the login screen with a **list of known servers** the user selects. Default behaviour is unchanged — **officetracker.com.au** is pre-selected.

The list shows:
- `officetracker.com.au` (default)
- `beta.officetracker.com.au`
- `officetracker.baileys.app`

An **"Enter a different server…"** row remains as the last option — it reveals the manual URL field for custom or anonymous instances (e.g. the read-only demo), so no capability is lost. The list is prioritised: it's shown first, with the **Sign in / Continue** button below it.

## Details

- New `KNOWN_SERVERS` list in `config.ts` (first entry matches `DEFAULT_BASE_URL`).
- Selecting a server probes `GET /api/v1/meta` (same as the existing manual-entry blur), so the button correctly shows **Continue** for an anonymous server and **Sign in** otherwise.
- Resuming with a previously-used custom server opens straight into manual mode with that URL prefilled.
- Sign in is disabled while manual mode has an empty URL.

## Notes

- Builds on #234 (merged).
- Touches `config.ts` and `LoginScreen.tsx` only. `tsc --noEmit` is clean for both (pre-existing errors in `LocationPicker.tsx`/`location.ts` are unrelated — a few packages aren't installed in this checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)