### PR TITLE
Auto-release Android to Play Store internal track in mobile CI

### DIFF
--- a/.github/workflows/mobile-eas-build.yaml
+++ b/.github/workflows/mobile-eas-build.yaml
@@ -1,12 +1,16 @@
 name: EAS Build
 
 # Builds the mobile app on Expo Application Services (EAS). Every push to
-# mobile-dev builds the ios production profile and auto-submits it to App Store
-# Connect (TestFlight). Can also be triggered manually with a chosen
-# platform/profile and an optional submit toggle. The build runs on EAS
-# infrastructure (not the GitHub runner); --no-wait queues it and returns, so
-# check progress at https://expo.dev. Requires an EXPO_TOKEN repo secret (an
-# Expo access token for the baelys-team account).
+# mobile-dev builds the production profile for both platforms and auto-submits
+# them: iOS to App Store Connect (TestFlight) and Android to the Play Store
+# internal track (eas.json -> submit.production.android.track). Can also be
+# triggered manually with a chosen platform/profile and an optional submit
+# toggle. The build runs on EAS infrastructure (not the GitHub runner);
+# --no-wait queues it and returns, so check progress at https://expo.dev.
+# Requires an EXPO_TOKEN repo secret (an Expo access token for the baelys-team
+# account). Store submission uses credentials saved in EAS: the App Store
+# Connect API key and the Google Play service account key (run `eas credentials`
+# once per platform to upload them).
 
 on:
   push:
@@ -58,7 +62,7 @@ jobs:
       - name: Build on EAS
         run: |
           eas build \
-            --platform ${{ inputs.platform || 'ios' }} \
+            --platform ${{ inputs.platform || 'all' }} \
             --profile ${{ inputs.profile || 'production' }} \
             --non-interactive \
             --no-wait \


### PR DESCRIPTION
## What

The mobile **EAS Build** workflow already auto-submitted **iOS → TestFlight** on every push to `mobile-dev`, but the push build defaulted to iOS only. This defaults the push build to **both platforms**, so Android is built and auto-submitted to the **Play Store internal testing track** (`eas.json` → `submit.production.android.track`) alongside iOS.

## Changes

- `.github/workflows/mobile-eas-build.yaml` — push build platform fallback `ios` → `all`; header comment updated.
- `mobile/README.md` — new **Continuous delivery** section documenting the flow and credentials.

No `eas.json` change needed: with `--no-wait`, submission runs on EAS infrastructure, so credentials live in EAS (uploaded via `eas credentials`), not the repo or runner.

## Required before this auto-submits Android

- [ ] The **Google Play service account key** is uploaded to EAS (`eas credentials`, Android). iOS/ASC is already set up since TestFlight submission works today.
- [ ] `EXPO_TOKEN` repo secret already present (used by existing iOS flow).

## Notes

- Each push now triggers **two** EAS builds (iOS + Android) instead of one.
- Android lands on the **internal** track; promotion to production is a separate step (and a new personal Play account must first run a 12-tester / 14-day closed test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)