### PR TITLE
Mobile: tag-only EAS builds + read-only mode looks like normal

### DIFF
--- a/.github/workflows/mobile-eas-build.yaml
+++ b/.github/workflows/mobile-eas-build.yaml
@@ -1,20 +1,22 @@
 name: EAS Build
 
-# Builds the mobile app on Expo Application Services (EAS). Every push to
-# mobile-dev builds the production profile for both platforms and auto-submits
-# them: iOS to App Store Connect (TestFlight) and Android to the Play Store
-# internal track (eas.json -> submit.production.android.track). Can also be
-# triggered manually with a chosen platform/profile and an optional submit
-# toggle. The build runs on EAS infrastructure (not the GitHub runner);
-# --no-wait queues it and returns, so check progress at https://expo.dev.
-# Requires an EXPO_TOKEN repo secret (an Expo access token for the baelys-team
-# account). Store submission uses credentials saved in EAS: the App Store
-# Connect API key and the Google Play service account key (run `eas credentials`
-# once per platform to upload them).
+# Builds the mobile app on Expo Application Services (EAS). Runs only when a new
+# version tag (v*) is pushed or when triggered manually — never on ordinary
+# commits. A tag push builds the production profile for both platforms and
+# auto-submits them: iOS to App Store Connect (TestFlight) and Android to the
+# Play Store internal track (eas.json -> submit.production.android.track). Manual
+# dispatch lets you pick the platform/profile and whether to submit. The build
+# runs on EAS infrastructure (not the GitHub runner); --no-wait queues it and
+# returns, so check progress at https://expo.dev. Requires an EXPO_TOKEN repo
+# secret (an Expo access token for the baelys-team account). Store submission
+# uses credentials saved in EAS: the App Store Connect API key and the Google
+# Play service account key (run `eas credentials` once per platform to upload
+# them).
 
 on:
   push:
-    branches: [mobile-dev]
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       platform:

--- a/mobile/src/api.ts
+++ b/mobile/src/api.ts
@@ -90,7 +90,7 @@ async function rawFetch(url: string, init?: RequestInit): Promise<Response> {
 }
 
 // How a server expects clients to authenticate. 'none' means the server serves
-// anonymous requests with no token (e.g. a public demo instance).
+// anonymous requests with no token (e.g. a public read-only instance).
 export type ServerAuth = 'auth0' | 'none';
 
 export interface ServerMeta {

--- a/mobile/src/screens/CalendarScreen.tsx
+++ b/mobile/src/screens/CalendarScreen.tsx
@@ -58,7 +58,7 @@ export default function CalendarScreen({
     [conn, onUnauthorized],
   );
 
-  // Read-only servers (e.g. the public demo) can be browsed but never written to.
+  // Read-only servers can be browsed but never written to.
   const readOnly = conn.readOnly;
 
   const [view, setView] = useState<ViewMonth>(thisMonth());
@@ -358,35 +358,27 @@ export default function CalendarScreen({
           </View>
 
           <Text style={styles.tip}>
-            {readOnly
-              ? 'This is a read-only demo — attendance is shown but cannot be edited.'
-              : 'Tap a day to cycle through home, office and other; long-press to go back.'}
+            Tap a day to cycle through home, office and other; long-press to go
+            back.
           </Text>
           <View style={styles.legendWrap}>
             <Legend />
           </View>
 
-          {(!readOnly || noteText) && (
-            <View style={styles.section}>
-              <Text style={styles.heading}>Notes</Text>
-              {readOnly ? (
-                <Text style={[styles.notes, styles.notesReadOnly]}>
-                  {noteText}
-                </Text>
-              ) : (
-                <TextInput
-                  style={styles.notes}
-                  value={noteText}
-                  onChangeText={setNoteText}
-                  onBlur={saveNote}
-                  placeholder={`Notes for ${formatMonthYear(view)}…`}
-                  placeholderTextColor={colors.textFaint}
-                  multiline
-                  textAlignVertical="top"
-                />
-              )}
-            </View>
-          )}
+          <View style={styles.section}>
+            <Text style={styles.heading}>Notes</Text>
+            <TextInput
+              style={styles.notes}
+              value={noteText}
+              onChangeText={setNoteText}
+              onBlur={saveNote}
+              editable={!readOnly}
+              placeholder={`Notes for ${formatMonthYear(view)}…`}
+              placeholderTextColor={colors.textFaint}
+              multiline
+              textAlignVertical="top"
+            />
+          </View>
 
           <View style={styles.section}>
             <Text style={styles.heading}>Summary</Text>
@@ -498,8 +490,5 @@ const styles = StyleSheet.create({
     color: colors.text,
     backgroundColor: colors.fieldBg,
     lineHeight: 21,
-  },
-  notesReadOnly: {
-    color: colors.textMuted,
   },
 });

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -235,13 +235,6 @@ export default function LoginScreen({
                   editable={!busy}
                 />
               )}
-
-              {anonymous && (
-                <Text style={styles.hint}>
-                  This server doesn&apos;t require sign in — it&apos;s a
-                  read-only demo.
-                </Text>
-              )}
             </View>
           ) : (
             <Pressable
@@ -357,12 +350,6 @@ const styles = StyleSheet.create({
     fontSize: 15,
     color: colors.text,
     backgroundColor: colors.fieldBg,
-  },
-  hint: {
-    marginTop: spacing.xs,
-    fontSize: 12,
-    color: colors.textFaint,
-    lineHeight: 17,
   },
   cancel: {
     marginTop: spacing.md,


### PR DESCRIPTION
Two mobile changes, both on top of the current `mobile-dev`.

## 1. EAS build runs only on tags / manual dispatch

The EAS pipeline triggered on every push to `mobile-dev`, so routine commits queued a production build and store submission. Now:

- `push` trigger restricted to version tags (`v*`); `workflow_dispatch` kept for manual builds. Commits never trigger the pipeline.
- A tag push still auto-submits both platforms (iOS → TestFlight, Android → Play Store internal track), so it lines up with cutting a release. Built on top of #236's both-platform submit.

## 2. Read-only servers look identical to normal mode

The read-only / anonymous ("public demo") experience announced itself and restyled the calendar. Now a read-only server is indistinguishable from a normal one, except writes are silently disabled:

- Dropped all user-facing "demo" wording (calendar tip, login hint).
- Calendar shows the same tip as normal mode.
- Notes field is always shown (disabled) even when empty, instead of being hidden or shown as plain text.
- `SettingsScreen` left as-is: its account/token sections stay hidden on a read-only server because the anonymous server returns no data for them.

## Verification

- `mobile-eas-build.yaml` validated as YAML; triggers are exactly `push` (tags `v*`) and `workflow_dispatch`.
- No user-facing `demo` strings remain in `mobile/src` (one internal code comment in `SettingsScreen` left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)