### PR TITLE
Migrate GCP project to officetracker-501000

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -31,16 +31,16 @@ jobs:
         run: docker build -t officetracker .
       - name: Tag docker image
         run: |
-          docker tag officetracker asia-southeast1-docker.pkg.dev/baileybutler-syd/officetracker/officetracker:${{ github.sha }}
-          docker tag officetracker asia-southeast1-docker.pkg.dev/baileybutler-syd/officetracker/officetracker:latest
+          docker tag officetracker asia-southeast1-docker.pkg.dev/officetracker-501000/officetracker/officetracker:${{ github.sha }}
+          docker tag officetracker asia-southeast1-docker.pkg.dev/officetracker-501000/officetracker/officetracker:latest
       - name: Authorise docker
         run: |
           gcloud auth configure-docker -q
           gcloud auth configure-docker asia-southeast1-docker.pkg.dev
       - name: Publish image
         run: |
-          docker push asia-southeast1-docker.pkg.dev/baileybutler-syd/officetracker/officetracker:${{ github.sha }}
-          docker push asia-southeast1-docker.pkg.dev/baileybutler-syd/officetracker/officetracker:latest
+          docker push asia-southeast1-docker.pkg.dev/officetracker-501000/officetracker/officetracker:${{ github.sha }}
+          docker push asia-southeast1-docker.pkg.dev/officetracker-501000/officetracker/officetracker:latest
 
   deploy:
     name: "Deploy"
@@ -66,9 +66,9 @@ jobs:
       - name: Deploy Cloud Run
         uses: google-github-actions/deploy-cloudrun@v3
         with:
-          project_id: baileybutler-syd
+          project_id: officetracker-501000
           service: ${{ inputs.service_name }}
-          image: asia-southeast1-docker.pkg.dev/baileybutler-syd/officetracker/officetracker:${{ github.sha }}
+          image: asia-southeast1-docker.pkg.dev/officetracker-501000/officetracker/officetracker:${{ github.sha }}
           region: asia-southeast1
           labels: |
             sha=${{ github.sha }}

--- a/.github/workflows/deploy-beta.yaml
+++ b/.github/workflows/deploy-beta.yaml
@@ -2,6 +2,12 @@ name: Deploy Beta
 
 on:
   workflow_dispatch:
+  # TEMPORARY: deploy beta on pushes to the migration branch so we can validate
+  # the new GCP project (officetracker-501000) end-to-end before merging.
+  # Remove this push trigger before merging to main.
+  push:
+    branches:
+      - worktree-gcp-project-migration
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-beta.yaml
+++ b/.github/workflows/deploy-beta.yaml
@@ -2,12 +2,6 @@ name: Deploy Beta
 
 on:
   workflow_dispatch:
-  # TEMPORARY: deploy beta on pushes to the migration branch so we can validate
-  # the new GCP project (officetracker-501000) end-to-end before merging.
-  # Remove this push trigger before merging to main.
-  push:
-    branches:
-      - worktree-gcp-project-migration
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker compose up
 
 Alternatively, pull the latest image:
 ```shell
-docker pull asia-southeast1-docker.pkg.dev/baileybutler-syd/officetracker/officetracker:latest
+docker pull asia-southeast1-docker.pkg.dev/officetracker-501000/officetracker/officetracker:latest
 ```
 
 ### Standalone Mode


### PR DESCRIPTION
## Summary
Repoints the build/deploy pipeline and docs from the old GCP project **`baileybutler-syd`** to the new **`officetracker-501000`**.

This is the code half of the GCP migration. The new project is **already fully provisioned** out-of-band:
- ✅ APIs enabled (Cloud Run, Artifact Registry, Secret Manager, IAM, Resource Manager)
- ✅ Artifact Registry repo `officetracker` (`asia-southeast1`)
- ✅ 7 Secret Manager secrets copied from the old project, values hash-verified identical
- ✅ Runtime SA (`…-compute@…`) granted `secretAccessor` on all secrets
- ✅ Deployer SA `github-deploy@officetracker-501000.iam.gserviceaccount.com` (`run.admin` + `artifactregistry.writer` + `iam.serviceAccountUser`)
- ✅ GitHub secrets updated: `SERVICE_TOKEN` repointed to the new SA key; name-holding secrets set to bare Secret Manager names (project-agnostic)

## Changes
- `.github/workflows/build-deploy.yaml` — Artifact Registry image paths (×5) + Cloud Run `project_id`
- `README.md` — `docker pull` example

## ⚠️ Before merging
- **Custom domains** (`officetracker.com.au` + `beta.officetracker.com.au`) still need DNS/domain-mapping set up in the new project — handled separately (click-ops).
- Merging triggers CICD, which will build → push to the new Artifact Registry → deploy to Cloud Run in `officetracker-501000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)