### PR TITLE
fix: stats-collector secret names + render last-updated in Melbourne time

### DIFF
--- a/.github/workflows/build-deploy-job.yaml
+++ b/.github/workflows/build-deploy-job.yaml
@@ -76,5 +76,5 @@ jobs:
             --region asia-southeast1 \
             --image asia-southeast1-docker.pkg.dev/officetracker-501000/officetracker/statscollector:${{ github.sha }} \
             --set-env-vars "${{ steps.env.outputs.vars }}" \
-            --set-secrets "SIGNING_KEY=SIGNING_KEY:latest,POSTGRES_PASSWORD=POSTGRES_PASSWORD:latest" \
+            --set-secrets "SIGNING_KEY=${{ secrets.SIGNING_KEY }}:latest,POSTGRES_PASSWORD=${{ secrets.PQ_SECRET }}:latest" \
             --labels "sha=${{ github.sha }}"

--- a/internal/server/templates.go
+++ b/internal/server/templates.go
@@ -168,7 +168,13 @@ func formatLastUpdated(computedAt string) string {
 	if err != nil {
 		return computedAt
 	}
-	return t.Local().Format("2 Jan 2006, 3:04 PM")
+	// Render in Melbourne time. The container runs in UTC, so t.Local() would
+	// show UTC; fall back to UTC only if the tz database is unavailable.
+	loc, err := time.LoadLocation("Australia/Melbourne")
+	if err != nil {
+		loc = time.UTC
+	}
+	return t.In(loc).Format("2 Jan 2006, 3:04 PM MST")
 }
 
 type ErrorPage struct {


### PR DESCRIPTION
## Problem
The `officetracker-stats-collector` Cloud Run **Job** deploy fails:

> Permission denied on secret: projects/616321703437/secrets/**SIGNING_KEY**/versions/latest ... POSTGRES_PASSWORD ...

Root cause: `build-deploy-job.yaml` mounted secrets by **literal names** `SIGNING_KEY` / `POSTGRES_PASSWORD`, which **don't exist** in `officetracker-501000`. The real Secret Manager secrets are `signing_key` and `officetracker_pq_pass` (GCP reports a missing secret as "permission denied"). The runtime SA (`…-compute@`) already has `secretAccessor` on the real secrets — the names were just wrong.

## Fix
Reference the secrets the same way `build-deploy.yaml` (the service) already does — via the GitHub-secret indirection, which `cicd.yaml` makes available through `secrets: inherit`:

- `SIGNING_KEY=${{ secrets.SIGNING_KEY }}:latest` → `signing_key`
- `POSTGRES_PASSWORD=${{ secrets.PQ_SECRET }}:latest` → `officetracker_pq_pass`

Merging re-triggers CICD, which will deploy the Job successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)