### PR TITLE
Standardise design language across web templates

### DIFF
--- a/internal/embed/html/bases/base.html
+++ b/internal/embed/html/bases/base.html
@@ -9,6 +9,17 @@
     <link href="https://fonts.googleapis.com/css2?family=Calistoga&display=swap" rel="stylesheet">
     <link href="/static/themes.css?v=2" rel="stylesheet">
     <style>
+        :root {
+            --ink: #24292e;
+            --ink-hover: #1c2025;
+            --muted: #6b7280;
+            --border: #dee2e6;
+            --divider: #f0f1f3;
+            --surface: #f8f9fa;
+            --radius-sm: 4px;
+            --radius-lg: 8px;
+        }
+
         html, body { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; margin: 0; padding: 0; }
         body { background-color: #f7f8f8; height: 100vh; overflow-x: hidden; overflow-y: auto; width: 100vw; }
         main { background-color: white; margin: 0 auto; max-width: 540px; min-height: calc(100vh - 96px); padding: 48px; }
@@ -27,11 +38,24 @@
             padding: 32px 48px 32px;
         }
 
+        button {
+            padding: 10px 16px;
+            border-radius: var(--radius-sm);
+            border: none;
+            background-color: var(--ink);
+            color: white;
+            cursor: pointer;
+            font-family: inherit;
+            font-size: inherit;
+        }
+        button:hover {
+            background-color: var(--ink-hover);
+        }
         .login-btn {
             padding: 10px;
-            border-radius: 4px;
+            border-radius: var(--radius-sm);
             border: none;
-            background-color: #24292e;
+            background-color: var(--ink);
             color: white;
             cursor: pointer;
             font-size: inherit;
@@ -41,7 +65,7 @@
             box-sizing: border-box;
         }
         .login-btn:hover {
-            background-color: #1c2025;
+            background-color: var(--ink-hover);
         }
         #calendar-nav {
             display: flex;
@@ -64,10 +88,10 @@
         }
 
         .weekday-header, .day {
-            border: 1px solid #dee2e6; /* Bootstrap-like border color */
+            border: 1px solid var(--border);
             padding: 0.5rem;
             text-align: center;
-            background-color: #f8f9fa; /* Bootstrap-like background color */
+            background-color: var(--surface);
         }
 
         .weekday-header {
@@ -97,7 +121,7 @@
         .legend-color {
             width: 1rem;
             height: 1rem;
-            border: 1px solid #dee2e6;
+            border: 1px solid var(--border);
             margin-right: 0.5rem;
         }
 
@@ -120,13 +144,13 @@
         textarea#notes {
             width: 100%;
             padding: 10px;
-            border: 1px solid #dee2e6;
-            border-radius: 4px;
-            font-family: Arial, sans-serif;
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            font-family: inherit;
             font-size: 1rem;
             line-height: 1.5;
             color: #495057;
-            background-color: #f8f9fa;
+            background-color: var(--surface);
             box-sizing: border-box;
             resize: vertical;
         }
@@ -137,56 +161,15 @@
         }
 
         .summary-container th, .summary-container td {
-            border: 1px solid #ddd;
+            border: 1px solid var(--border);
             padding: 8px;
             text-align: left;
         }
 
         .summary-container th {
-            background-color: #f4f4f4;
+            background-color: var(--surface);
         }
 
-        input#api-key {
-            width: 100%;
-        }
-        
-        /* Theme selector styles */
-        .theme-selector {
-            margin: 1rem 0;
-        }
-        
-        .theme-selector label {
-            display: block;
-            margin-bottom: 0.5rem;
-        }
-        
-        .theme-selector select {
-            padding: 0.5rem;
-            border-radius: 4px;
-            border: 1px solid #dee2e6;
-            background-color: white;
-            color: #495057;
-        }
-        
-        .theme-option {
-            margin: 0.5rem 0;
-        }
-        
-        .theme-option label {
-            margin-left: 0.5rem;
-        }
-        
-        /* Improved checkbox styling */
-        .checkbox-wrapper {
-            display: flex;
-            align-items: center;
-        }
-        
-        .checkbox-wrapper input[type="checkbox"] {
-            margin: 0;
-            margin-right: 0.5rem;
-        }
-        
         /* Schedule calendar styles */
         .schedule-container {
             margin: 1rem 0;
@@ -198,7 +181,7 @@
         }
         
         .schedule-day {
-            border: 1px solid #dee2e6;
+            border: 1px solid var(--border);
             padding: 1rem;
             text-align: center;
             cursor: pointer;
@@ -211,7 +194,7 @@
         }
         
         .schedule-day[data-state="0"] {
-            background-color: #f8f9fa; /* Untracked */
+            background-color: var(--surface); /* Untracked */
         }
         
         .schedule-day[data-state="1"] {
@@ -244,7 +227,7 @@
             background-color: #333;
             color: white;
             padding: 8px 12px;
-            border-radius: 4px;
+            border-radius: var(--radius-sm);
             font-size: 0.85em;
             white-space: nowrap;
             z-index: 1000;
@@ -285,10 +268,10 @@
     <h2>{{block "title" .}}{{end}}</h2>
     <section>{{block "content" .}}{{end}}</section>
     
-    <footer style="margin-top: 48px; padding: 24px 0; border-top: 1px solid #dee; text-align: center; color: #666;">
+    <footer style="margin-top: 48px; padding: 24px 0; border-top: 1px solid #dee; text-align: center; color: #6b7280;">
         <p>
-            <a href="/tos" style="margin: 0 8px; color: #666;">Terms of Service</a>
-            <a href="/privacy" style="margin: 0 8px; color: #666;">Privacy Policy</a>
+            <a href="/tos" style="margin: 0 8px; color: #6b7280;">Terms of Service</a>
+            <a href="/privacy" style="margin: 0 8px; color: #6b7280;">Privacy Policy</a>
         </p>
     </footer>
 </main>

--- a/internal/embed/html/developer.html
+++ b/internal/embed/html/developer.html
@@ -13,28 +13,17 @@
     #token-name {
         flex: 1;
         padding: 0.5rem;
-        border: 1px solid #dee2e6;
-        border-radius: 4px;
-        background-color: #f8f9fa;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background-color: var(--surface);
         color: #495057;
-    }
-    #generate-token-btn {
-        padding: 10px;
-        background: #24292e;
-        color: white;
-        border: none;
-        border-radius: 4px;
-        cursor: pointer;
-    }
-    #generate-token-btn:hover {
-        background: #1c2025;
     }
     #new-token-display {
         margin-top: 1rem;
         padding: 1rem;
-        background: #f8f9fa;
-        border: 1px solid #dee2e6;
-        border-radius: 4px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
     }
     .token-warning {
         margin-bottom: 0.5rem;
@@ -47,59 +36,40 @@
         flex: 1;
         padding: 0.5rem;
         background: white;
-        border: 1px solid #dee2e6;
-        border-radius: 4px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
         font-family: monospace;
-    }
-    #copy-token-btn {
-        padding: 10px;
-        background: #24292e;
-        color: white;
-        border: none;
-        border-radius: 4px;
-        cursor: pointer;
-    }
-    #copy-token-btn:hover {
-        background: #1c2025;
     }
     .tokens-table {
         width: 100%;
         border-collapse: collapse;
     }
     .tokens-table th {
-        background: #f4f4f4;
+        background: var(--surface);
         padding: 8px;
         text-align: left;
-        border: 1px solid #ddd;
+        border: 1px solid var(--border);
     }
     .tokens-table td {
         padding: 8px;
-        border: 1px solid #ddd;
+        border: 1px solid var(--border);
     }
     .revoke-btn {
         padding: 6px 12px;
-        background: #24292e;
-        color: white;
-        border: none;
-        border-radius: 4px;
-        cursor: pointer;
-    }
-    .revoke-btn:hover {
-        background: #1c2025;
     }
     .no-tokens {
         padding: 1rem;
         text-align: center;
-        color: #666;
-        background: #f8f9fa;
-        border-radius: 4px;
+        color: var(--muted);
+        background: var(--surface);
+        border-radius: var(--radius-lg);
     }
     .error {
         padding: 1rem;
-        background: #f8f9fa;
+        background: var(--surface);
         color: #495057;
-        border: 1px solid #dee2e6;
-        border-radius: 4px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
     }
 </style>
 

--- a/internal/embed/html/hero.html
+++ b/internal/embed/html/hero.html
@@ -3,10 +3,10 @@
 {{ define "content" }}
 <style>
     .hero {
-        background: #eef8f6 url("/static/office-building.png") no-repeat right 32px bottom 24px / 152px 152px;
-        margin: 0 -24px 32px;
+        background: #eef8f6 url("/static/office-building.png") no-repeat right 48px bottom 24px / 152px 152px;
+        margin: 0 -48px 32px;
         min-height: 360px;
-        padding: 32px 180px 32px 24px;
+        padding: 32px 200px 32px 48px;
     }
 
     .hero p {
@@ -24,9 +24,9 @@
     }
 
     .hero-actions a {
-        border: 1px solid #24292e;
-        border-radius: 4px;
-        color: #24292e;
+        border: 1px solid var(--ink);
+        border-radius: var(--radius-sm);
+        color: var(--ink);
         display: inline-flex;
         font-weight: 700;
         line-height: 1;
@@ -35,7 +35,7 @@
     }
 
     .hero-actions a.primary {
-        background-color: #24292e;
+        background-color: var(--ink);
         color: white;
     }
 
@@ -52,7 +52,7 @@
     }
 
     .hero-details p {
-        color: #526064;
+        color: var(--muted);
         line-height: 1.45;
         margin: 0;
     }
@@ -61,8 +61,6 @@
         .hero {
             background-position: right 20px bottom 20px;
             background-size: 96px 96px;
-            margin-left: 0;
-            margin-right: 0;
             min-height: 420px;
             padding: 24px 24px 132px;
         }

--- a/internal/embed/html/settings.html
+++ b/internal/embed/html/settings.html
@@ -4,8 +4,8 @@
 
 <style>
     .settings-section {
-        border: 1px solid #e6e8eb;
-        border-radius: 10px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
         padding: 20px 24px;
         margin: 20px 0;
     }
@@ -17,7 +17,7 @@
 
     .settings-section .section-desc {
         margin: 0 0 16px;
-        color: #6b7280;
+        color: var(--muted);
         font-size: 0.875rem;
         line-height: 1.5;
     }
@@ -36,7 +36,7 @@
     }
 
     .field-row + .field-row {
-        border-top: 1px solid #f0f1f3;
+        border-top: 1px solid var(--divider);
     }
 
     .field-row label {
@@ -46,8 +46,8 @@
 
     .field-row select {
         padding: 8px 10px;
-        border-radius: 6px;
-        border: 1px solid #dee2e6;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
         background-color: #fff;
         color: #495057;
         font-size: 0.95rem;
@@ -74,11 +74,11 @@
     }
 
     .account-list li + li {
-        border-top: 1px solid #f0f1f3;
+        border-top: 1px solid var(--divider);
     }
 
     .account-list .empty {
-        color: #6b7280;
+        color: var(--muted);
     }
 
     /* Schedule calendar tweaks */
@@ -102,7 +102,7 @@
     <p class="section-desc">
         Link an additional social login to your account. Connection links expire after 10 minutes.
     </p>
-    <a href="{{.Auth0AuthURL}}" class="github-btn login-btn" id="assoc-uri">
+    <a href="{{.Auth0AuthURL}}" class="login-btn" id="assoc-uri">
         Connect a social login
     </a>
     <ul class="account-list">

--- a/internal/embed/html/stats.html
+++ b/internal/embed/html/stats.html
@@ -3,7 +3,7 @@
 {{ define "content" }}
 <style>
     .stats-updated {
-        color: #666;
+        color: var(--muted);
         font-size: 0.85rem;
         margin-bottom: 1.5rem;
     }
@@ -11,11 +11,8 @@
         margin-bottom: 2rem;
     }
     .stats-group h3 {
-        margin-bottom: 0.75rem;
-        font-size: 1rem;
-        color: #495057;
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
+        margin: 0 0 0.75rem;
+        font-size: 1.05rem;
     }
     .stats-grid {
         display: grid;
@@ -23,14 +20,14 @@
         gap: 1rem;
     }
     .stat-card {
-        background: #f8f9fa;
-        border: 1px solid #dee2e6;
-        border-radius: 8px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
         padding: 1.25rem;
     }
     .stat-card .stat-title {
         font-size: 0.85rem;
-        color: #666;
+        color: var(--muted);
         margin-bottom: 0.5rem;
     }
     .stat-card .stat-value {
@@ -41,16 +38,16 @@
     .stat-card .stat-unit {
         font-size: 0.9rem;
         font-weight: 400;
-        color: #888;
+        color: var(--muted);
         margin-left: 0.25rem;
     }
     .stats-empty {
         padding: 1.5rem;
         text-align: center;
-        color: #666;
-        background: #f8f9fa;
-        border: 1px solid #dee2e6;
-        border-radius: 8px;
+        color: var(--muted);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
     }
 </style>
 


### PR DESCRIPTION
## Summary

The web UI had drifted into several slightly different styles per page. This standardises everything onto the existing flat, minimal language (white card, teal nav, dark flat buttons) via shared CSS custom properties in `base.html`.

- **Calendar page buttons** (Previous/Next, Export CSV/PDF) were unstyled native browser buttons — now styled globally to match the flat dark `#24292e` button used on every other page
- **Design tokens** added in `base.html` (`--ink`, `--muted`, `--border`, `--divider`, `--surface`, `--radius-sm`, `--radius-lg`) and applied across settings, stats, developer and hero templates
- **Border radii** standardised: 4px controls, 8px cards/panels (was a mix of 4/6/8/10px)
- **Borders and greys** unified: `#ddd`/`#e6e8eb` → `#dee2e6`; muted text `#666`/`#888`/`#526064` → `#6b7280`; table headers `#f4f4f4` → `#f8f9fa`
- **Hero panel** now bleeds full width like the nav and notification sections (was inset 24px)
- **Stats group headings** match settings section headings (dropped the uppercase/letter-spacing one-off)
- Notes textarea inherits the app font instead of Arial
- Removed dead CSS (`.theme-selector`, `.theme-option`, `.checkbox-wrapper`, `input#api-key`) and per-page duplicate button styles in developer.html

No markup structure, JS behaviour, or theme-system (dark/city-skyline) changes; themes.css overrides still apply on top.

## Testing

- `go build -tags=integrated` passes
- Ran the full docker compose stack locally and verified the calendar page renders correctly with the mock OIDC login

🤖 Generated with [Claude Code](https://claude.com/claude-code)