### PR TITLE
Add two-tier per-client rate limiting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/redis/go-redis/v9 v9.21.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.38.0
+	golang.org/x/time v0.15.0
 	google.golang.org/api v0.287.0
 )
 
@@ -60,7 +61,6 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect

--- a/internal/database/redis.go
+++ b/internal/database/redis.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -24,6 +25,69 @@ func NewRedis(cfg config.Redis) (*Redis, error) {
 	return &Redis{
 		rdb: rdb,
 	}, nil
+}
+
+// rateLimitScript refills and claims a token from both of a client's token
+// buckets in one atomic step. The hash at KEYS[1] holds the minute-bucket
+// tokens (m), hour-bucket tokens (h) and the last refill time in microseconds
+// (t); buckets start full. ARGV: minute capacity, hour capacity, now in
+// microseconds. Returns {allowed, retry-after in milliseconds}.
+var rateLimitScript = redis.NewScript(`
+local per_minute = tonumber(ARGV[1])
+local per_hour = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+
+local state = redis.call('HMGET', KEYS[1], 'm', 'h', 't')
+local m = tonumber(state[1])
+local h = tonumber(state[2])
+local t = tonumber(state[3])
+if m == nil then
+	m = per_minute
+	h = per_hour
+	t = now
+end
+
+if now > t then
+	local elapsed = (now - t) / 1000000
+	m = math.min(m + elapsed * per_minute / 60, per_minute)
+	h = math.min(h + elapsed * per_hour / 3600, per_hour)
+	t = now
+end
+
+local allowed = 0
+local retry_ms = 0
+if m >= 1 and h >= 1 then
+	allowed = 1
+	m = m - 1
+	h = h - 1
+else
+	local wait_m = 0
+	local wait_h = 0
+	if m < 1 then wait_m = (1 - m) * 60 / per_minute end
+	if h < 1 then wait_h = (1 - h) * 3600 / per_hour end
+	retry_ms = math.ceil(math.max(wait_m, wait_h) * 1000)
+end
+
+redis.call('HSET', KEYS[1], 'm', m, 'h', h, 't', t)
+redis.call('EXPIRE', KEYS[1], 3600)
+return {allowed, retry_ms}
+`)
+
+// RateLimitAllow atomically claims a token from each of the client's two
+// token buckets (a per-minute burst bucket and a per-hour sustained bucket),
+// creating them full on first use. It reports whether the request is allowed
+// and, when denied, how long the client should wait before retrying. Denied
+// requests do not consume tokens. Bucket state expires after an hour idle, by
+// which time both buckets are full again anyway.
+func (r *Redis) RateLimitAllow(ctx context.Context, key string, perMinute, perHour int, now time.Time) (bool, time.Duration, error) {
+	res, err := rateLimitScript.Run(ctx, r.rdb, []string{key}, perMinute, perHour, now.UnixMicro()).Int64Slice()
+	if err != nil {
+		return false, 0, err
+	}
+	if len(res) != 2 {
+		return false, 0, fmt.Errorf("unexpected rate limit script result: %v", res)
+	}
+	return res[0] == 1, time.Duration(res[1]) * time.Millisecond, nil
 }
 
 func (r *Redis) SetState(ctx context.Context, key string, value interface{}, expiration time.Duration) error {

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"math"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type rateLimits struct {
+	perMinute int // short-window burst allowance
+	perHour   int // sustained hourly cap
+}
+
+// Limits applied per client, tracked in memory per instance. Authenticated
+// requests are limited per user; everything else per client IP, on a much
+// tighter budget.
+var (
+	authedRateLimits = rateLimits{perMinute: 120, perHour: 1200}
+	// A flat hourly cap for unauthenticated clients: the minute bucket
+	// matches the hour bucket, so the whole allowance may be spent in a
+	// single burst.
+	unauthedRateLimits = rateLimits{perMinute: 120, perHour: 120}
+)
+
+const (
+	// After an hour idle both buckets are full again, so an evicted entry is
+	// indistinguishable from a fresh one.
+	limiterIdleEviction = time.Hour
+	limiterSweepEvery   = 5 * time.Minute
+)
+
+// clientLimiter holds the two token buckets for a single client. A request
+// must claim a token from both: the minute bucket permits short bursts while
+// the hour bucket caps sustained usage.
+type clientLimiter struct {
+	minute   *rate.Limiter
+	hour     *rate.Limiter
+	lastSeen time.Time
+}
+
+type rateLimiter struct {
+	authed   rateLimits
+	unauthed rateLimits
+
+	mu        sync.Mutex
+	clients   map[string]*clientLimiter
+	lastSweep time.Time
+}
+
+func newRateLimiter(authed, unauthed rateLimits) *rateLimiter {
+	return &rateLimiter{
+		authed:   authed,
+		unauthed: unauthed,
+		clients:  make(map[string]*clientLimiter),
+	}
+}
+
+func (rl *rateLimiter) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key, limits := rl.client(r)
+		ok, retryAfter := rl.allow(key, limits, time.Now())
+		if !ok {
+			w.Header().Set("Retry-After", strconv.Itoa(int(math.Ceil(retryAfter.Seconds()))))
+			writeError(w, "rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// client identifies the requester and the limits that apply to it:
+// authenticated requests are limited per user, everything else per client IP.
+func (rl *rateLimiter) client(r *http.Request) (string, rateLimits) {
+	if userID, err := getUserID(r); err == nil && userID != 0 {
+		return "user:" + strconv.Itoa(userID), rl.authed
+	}
+	return "ip:" + clientIP(r), rl.unauthed
+}
+
+// allow reports whether the client identified by key may proceed at time now.
+// When denied it also returns how long the client should wait before retrying.
+func (rl *rateLimiter) allow(key string, limits rateLimits, now time.Time) (bool, time.Duration) {
+	c := rl.limiterFor(key, limits, now)
+
+	minuteRes := c.minute.ReserveN(now, 1)
+	hourRes := c.hour.ReserveN(now, 1)
+	minuteDelay := minuteRes.DelayFrom(now)
+	hourDelay := hourRes.DelayFrom(now)
+	if minuteDelay == 0 && hourDelay == 0 {
+		return true, 0
+	}
+
+	// Denied: return both claimed tokens so the rejected attempt doesn't
+	// count against either limit.
+	minuteRes.CancelAt(now)
+	hourRes.CancelAt(now)
+	return false, max(minuteDelay, hourDelay)
+}
+
+func (rl *rateLimiter) limiterFor(key string, limits rateLimits, now time.Time) *clientLimiter {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	if now.Sub(rl.lastSweep) >= limiterSweepEvery {
+		rl.lastSweep = now
+		for k, c := range rl.clients {
+			if now.Sub(c.lastSeen) >= limiterIdleEviction {
+				delete(rl.clients, k)
+			}
+		}
+	}
+
+	c, ok := rl.clients[key]
+	if !ok {
+		c = &clientLimiter{
+			minute: rate.NewLimiter(rate.Limit(float64(limits.perMinute)/60), limits.perMinute),
+			hour:   rate.NewLimiter(rate.Limit(float64(limits.perHour)/3600), limits.perHour),
+		}
+		rl.clients[key] = c
+	}
+	c.lastSeen = now
+	return c
+}
+
+// clientIP returns the requesting client's IP. On Cloud Run the rightmost
+// X-Forwarded-For entry is appended by Google's front end and is trustworthy;
+// with no proxy in front the header is absent and RemoteAddr is used.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.Split(xff, ",")
+		return strings.TrimSpace(parts[len(parts)-1])
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"math"
 	"net"
 	"net/http"
@@ -10,6 +13,8 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
+
+	"github.com/baely/officetracker/internal/database"
 )
 
 type rateLimits struct {
@@ -17,9 +22,8 @@ type rateLimits struct {
 	perHour   int // sustained hourly cap
 }
 
-// Limits applied per client, tracked in memory per instance. Authenticated
-// requests are limited per user; everything else per client IP, on a much
-// tighter budget.
+// Limits applied per client. Authenticated requests are limited per user;
+// everything else per client IP, on a much tighter budget.
 var (
 	authedRateLimits = rateLimits{perMinute: 120, perHour: 1200}
 	// A flat hourly cap for unauthenticated clients: the minute bucket
@@ -35,28 +39,35 @@ const (
 	limiterSweepEvery   = 5 * time.Minute
 )
 
-// clientLimiter holds the two token buckets for a single client. A request
-// must claim a token from both: the minute bucket permits short bursts while
-// the hour bucket caps sustained usage.
+// clientLimiter holds the two in-memory token buckets for a single client. A
+// request must claim a token from both: the minute bucket permits short
+// bursts while the hour bucket caps sustained usage.
 type clientLimiter struct {
 	minute   *rate.Limiter
 	hour     *rate.Limiter
 	lastSeen time.Time
 }
 
+// rateLimiter enforces per-client limits. With Redis available the buckets
+// live there, shared across all instances; without it (standalone mode) each
+// instance keeps its own in-memory buckets.
 type rateLimiter struct {
 	authed   rateLimits
 	unauthed rateLimits
 
+	redis *database.Redis // nil in standalone mode
+
+	// In-memory fallback state, used only when redis is nil.
 	mu        sync.Mutex
 	clients   map[string]*clientLimiter
 	lastSweep time.Time
 }
 
-func newRateLimiter(authed, unauthed rateLimits) *rateLimiter {
+func newRateLimiter(redis *database.Redis, authed, unauthed rateLimits) *rateLimiter {
 	return &rateLimiter{
 		authed:   authed,
 		unauthed: unauthed,
+		redis:    redis,
 		clients:  make(map[string]*clientLimiter),
 	}
 }
@@ -64,7 +75,7 @@ func newRateLimiter(authed, unauthed rateLimits) *rateLimiter {
 func (rl *rateLimiter) middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		key, limits := rl.client(r)
-		ok, retryAfter := rl.allow(key, limits, time.Now())
+		ok, retryAfter := rl.allow(r.Context(), key, limits, time.Now())
 		if !ok {
 			w.Header().Set("Retry-After", strconv.Itoa(int(math.Ceil(retryAfter.Seconds()))))
 			writeError(w, "rate limit exceeded", http.StatusTooManyRequests)
@@ -85,7 +96,20 @@ func (rl *rateLimiter) client(r *http.Request) (string, rateLimits) {
 
 // allow reports whether the client identified by key may proceed at time now.
 // When denied it also returns how long the client should wait before retrying.
-func (rl *rateLimiter) allow(key string, limits rateLimits, now time.Time) (bool, time.Duration) {
+func (rl *rateLimiter) allow(ctx context.Context, key string, limits rateLimits, now time.Time) (bool, time.Duration) {
+	if rl.redis == nil {
+		return rl.allowInMemory(key, limits, now)
+	}
+	ok, retryAfter, err := rl.redis.RateLimitAllow(ctx, "ratelimit:"+key, limits.perMinute, limits.perHour, now)
+	if err != nil {
+		// Fail open: a Redis outage shouldn't take the site down.
+		slog.Error(fmt.Sprintf("rate limit check failed, allowing request: %v", err))
+		return true, 0
+	}
+	return ok, retryAfter
+}
+
+func (rl *rateLimiter) allowInMemory(key string, limits rateLimits, now time.Time) (bool, time.Duration) {
 	c := rl.limiterFor(key, limits, now)
 
 	minuteRes := c.minute.ReserveN(now, 1)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -48,7 +48,8 @@ func NewServer(cfg config.AppConfigurer, db database.Databaser, redis *database.
 	}
 	s.auth = author
 
-	r := chi.NewMux().With(injectAuth(db, cfg), s.logRequest)
+	limiter := newRateLimiter(authedRateLimits, unauthedRateLimits)
+	r := chi.NewMux().With(injectAuth(db, cfg), s.logRequest, limiter.middleware)
 
 	// Suspension page (must be accessible to suspended users)
 	r.Get("/suspended", s.handleSuspended)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -48,7 +48,7 @@ func NewServer(cfg config.AppConfigurer, db database.Databaser, redis *database.
 	}
 	s.auth = author
 
-	limiter := newRateLimiter(authedRateLimits, unauthedRateLimits)
+	limiter := newRateLimiter(redis, authedRateLimits, unauthedRateLimits)
 	r := chi.NewMux().With(injectAuth(db, cfg), s.logRequest, limiter.middleware)
 
 	// Suspension page (must be accessible to suspended users)


### PR DESCRIPTION
## Summary

Adds rate limiting middleware covering every route, with two client tiers:

- **Authenticated users** (keyed per user ID): a minute bucket allowing bursts of up to 120 requests, plus an hour bucket capping sustained usage at 1200 requests. A request must claim a token from both.
- **Unauthenticated clients** (keyed per client IP): a flat 120 requests per hour, spendable in a single burst.

In integrated mode the buckets live in **Redis**, shared across all instances, updated by an atomic Lua script — one round trip per request refills both buckets and claims a token from each. Standalone mode (no Redis) falls back to in-memory buckets built on `golang.org/x/time/rate` (already in the module graph; promoted to a direct dependency).

Over-limit requests receive a 429 JSON error with a `Retry-After` header; denied attempts don't consume tokens. Client IP comes from the rightmost `X-Forwarded-For` entry (appended by Cloud Run's front end) with `RemoteAddr` as the fallback. Bucket state expires after an hour idle, by which time the buckets are full again anyway.

## Notes

- Redis errors **fail open** (request allowed, error logged) so a Redis outage doesn't take the site down.
- Standalone mode always resolves to user ID 1, so a standalone instance shares one authenticated-tier budget.
- Verified locally: builds under both `standalone` and `integrated` tags, `go vet` clean, and a local (uncommitted, per request) test suite covering burst/hourly caps, refill timing, tier separation, key independence, eviction, and the middleware end-to-end — including integration tests running the Lua script against a real Redis and confirming exact refill/`Retry-After` behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)