### PR TITLE
stats: enable GCP cost widgets (billing export is live)

### DIFF
--- a/config/cloud.env
+++ b/config/cloud.env
@@ -23,11 +23,7 @@ OTEL_EXPORTER_OTLP_HEADERS=x-honeycomb-team=bUVRiWlks5t6EHmeDKQBWE
 # once the log sink and billing export exist.
 STATS_BQ_PROJECT_ID=officetracker-501000
 STATS_BQ_LOGS_TABLE=officetracker_logs.run_googleapis_com_stdout
-# Blank until the Cloud Billing export table exists (export was enabled ~2026-07-01,
-# takes a few hours to first populate). While blank, the GCP-cost and
-# cost-per-user widgets are skipped. Set to the following once the table appears:
-#   officetracker_billing.gcp_billing_export_v1_00CB17_E58D3F_47FC6F
-STATS_BQ_BILLING_TABLE=
+STATS_BQ_BILLING_TABLE=officetracker_billing.gcp_billing_export_v1_00CB17_E58D3F_47FC6F
 # Required to scope billing to this project only (the billing export table holds
 # every project under the billing account).
 STATS_BQ_BILLING_PROJECT_ID=officetracker-501000


### PR DESCRIPTION
## What
Un-blanks `STATS_BQ_BILLING_TABLE` in `config/cloud.env` now that the Cloud Billing → BigQuery export has populated.

```
STATS_BQ_BILLING_TABLE=officetracker_billing.gcp_billing_export_v1_00CB17_E58D3F_47FC6F
```

## Why now
The billing export table now has data — verified:
- **799 rows**, `currency = AUD`, net 30-day cost ≈ **$0.0093** (free tier).
- AUD matches the fixed-cost constants, so **no currency mismatch** (the earlier open question).

With the table wired, `Config.BillingEnabled()` returns true, so the collector now emits the **GCP Cost** and **Cost-per-User** widgets (previously skipped cleanly while blank).

## After merge
CICD redeploys the collector Job with the new env. The widgets appear on the **next collector run** — the 12-hourly Cloud Scheduler will pick it up, or run `gcloud run jobs execute officetracker-stats-collector --region asia-southeast1` for an immediate refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)