### PR TITLE
Cut over prod to Sydney region

### DIFF
--- a/.github/workflows/build-deploy-job.yaml
+++ b/.github/workflows/build-deploy-job.yaml
@@ -73,7 +73,7 @@ jobs:
         run: |
           gcloud run jobs deploy ${{ inputs.job_name }} \
             --project officetracker-501000 \
-            --region asia-southeast1 \
+            --region australia-southeast1 \
             --image asia-southeast1-docker.pkg.dev/officetracker-501000/officetracker/statscollector:${{ github.sha }} \
             --set-env-vars "${{ steps.env.outputs.vars }}" \
             --set-secrets "SIGNING_KEY=${{ secrets.SIGNING_KEY }}:latest,POSTGRES_PASSWORD=${{ secrets.PQ_SECRET }}:latest" \

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -69,7 +69,7 @@ jobs:
           project_id: officetracker-501000
           service: ${{ inputs.service_name }}
           image: asia-southeast1-docker.pkg.dev/officetracker-501000/officetracker/officetracker:${{ github.sha }}
-          region: asia-southeast1
+          region: australia-southeast1
           labels: |
             sha=${{ github.sha }}
           env_vars: ${{ steps.env.outputs.ENV_VARS }}

--- a/config/cloud.env
+++ b/config/cloud.env
@@ -3,9 +3,9 @@ DOMAIN_PROTOCOL=https
 DOMAIN_SUBDOMAIN=
 DOMAIN_DOMAIN=officetracker.com.au
 DOMAIN_BASE_PATH=/
-POSTGRES_USER=postgres.dfjnlepvxrwlkavudaci
-POSTGRES_HOST=aws-0-ap-southeast-1.pooler.supabase.com
-POSTGRES_PORT=6543
+POSTGRES_USER=postgres
+POSTGRES_HOST=db.eukeuureahwuzbftdred.supabase.co
+POSTGRES_PORT=5432
 POSTGRES_DBNAME=postgres
 REDIS_HOST=redis-13899.c337.australia-southeast1-1.gce.redns.redis-cloud.com:13899
 REDIS_USERNAME=default
@@ -18,14 +18,9 @@ OTEL_SERVICE_NAME=officetracker
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io
 OTEL_EXPORTER_OTLP_HEADERS=x-honeycomb-team=bUVRiWlks5t6EHmeDKQBWE
-# Stats collector (used by the stats-collector Cloud Run Job). Leave BQ vars
-# blank to run with DB-backed + fixed-cost widgets only. TODO: fill BQ tables
-# once the log sink and billing export exist.
 STATS_BQ_PROJECT_ID=officetracker-501000
 STATS_BQ_LOGS_TABLE=officetracker_logs.run_googleapis_com_stdout
 STATS_BQ_BILLING_TABLE=officetracker_billing.gcp_billing_export_v1_00CB17_E58D3F_47FC6F
-# Required to scope billing to this project only (the billing export table holds
-# every project under the billing account).
 STATS_BQ_BILLING_PROJECT_ID=officetracker-501000
 STATS_COST_SUPABASE=0
 STATS_COST_REDIS=0


### PR DESCRIPTION
## What

Cut the production stack over from **Singapore (`asia-southeast1`)** to **Sydney (`australia-southeast1`)**, co-located with the new Sydney Supabase database.

## Changes

- **`build-deploy.yaml`** — `officetracker` Cloud Run service region → `australia-southeast1`
- **`build-deploy-job.yaml`** — `officetracker-stats-collector` Cloud Run Job region → `australia-southeast1`
- **`config/cloud.env`** — Postgres now points at the Sydney Supabase DB (`db.eukeuureahwuzbftdred.supabase.co`)

The **Artifact Registry stays in `asia-southeast1`** (`asia-southeast1-docker.pkg.dev`) — deliberately unchanged.

## Data

The ~10.8k rows across all 8 public tables were cloned Singapore → Sydney out-of-band and verified (row counts + sequences match). This PR is config only.

## Before merge / deploy

- [ ] Point GCP secret `officetracker_pq_pass` at the Sydney DB password
- [ ] After deploy, confirm the service is healthy on the Sydney DB, then tear down the Singapore Supabase project + Cloud Run

## Not covered here (follow-ups for the Singapore teardown)

- `officetracker-beta` (`deploy-beta.yaml` / `config/beta.env`) still targets `asia-southeast1` + the old Singapore DB
- The stats-collector's Cloud Scheduler trigger was a one-time manual setup in `asia-southeast1`; it needs recreating in `australia-southeast1` or the job won't fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)
