### PR TITLE
Fix Dark theme consistency across the app

### DIFF
--- a/internal/embed/html/bases/base.html
+++ b/internal/embed/html/bases/base.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Calistoga&display=swap" rel="stylesheet">
-    <link href="/static/themes.css?v=2" rel="stylesheet">
+    <link href="/static/themes.css?v=3" rel="stylesheet">
     <style>
         html, body { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; margin: 0; padding: 0; }
         body { background-color: #f7f8f8; height: 100vh; overflow-x: hidden; overflow-y: auto; width: 100vw; }

--- a/internal/embed/static/themes.css
+++ b/internal/embed/static/themes.css
@@ -216,11 +216,13 @@
 
 /* Dark theme */
 .theme-dark {
-    --primary-bg: #333;
-    --secondary-bg: #222;
-    --content-bg: #444;
-    --text-color: #ddd;
-    --border-color: #555;
+    --primary-bg: #202124;    /* page background */
+    --secondary-bg: #17181a;  /* navbar */
+    --content-bg: #2a2b2e;    /* content card */
+    --input-bg: #2f3033;      /* inputs, buttons, table headers */
+    --text-color: #e3e3e3;
+    --muted-text: #9aa0a6;    /* secondary/descriptive text */
+    --border-color: #3c4043;
     --highlight-color: #FFC107;
     --present-color: #4CAF50;
     --not-present-color: #F44336;
@@ -242,7 +244,8 @@ body.theme-city-skyline main {
 }
 
 body.theme-dark main nav {
-    background-color: var(--secondary-bg);
+    /* Base `main nav` sets #dee with !important, so this must be !important too. */
+    background-color: var(--secondary-bg) !important;
 }
 
 body.theme-dark .weekday-header, 
@@ -298,6 +301,82 @@ body.theme-city-skyline .scheduled-other {
 body.theme-dark .today,
 body.theme-city-skyline .today {
     border-color: var(--highlight-color);
+}
+
+/* -------------------------------------------------------------------------
+   Dark theme — consistency fixes.
+   The app's base styles are light-first with many hardcoded colours the
+   original dark theme never covered (white inputs, tables, dividers, etc.).
+   These rules bring the rest of the UI in line with the dark palette. They are
+   all scoped to body.theme-dark, so the other themes are left untouched. */
+
+/* Secondary / descriptive text */
+body.theme-dark .section-desc,
+body.theme-dark .account-list .empty {
+    color: var(--muted-text);
+}
+
+/* Form controls: inputs, selects, textareas (excluding native checkboxes) */
+body.theme-dark input:not([type="checkbox"]):not([type="radio"]),
+body.theme-dark select,
+body.theme-dark textarea,
+body.theme-dark textarea#notes,
+body.theme-dark .field-row select {
+    background-color: var(--input-bg);
+    color: var(--text-color);
+    border-color: var(--border-color);
+}
+
+/* Default buttons (calendar nav, export). The dedicated .login-btn keeps its
+   own dark styling. */
+body.theme-dark button:not(.login-btn) {
+    background-color: var(--input-bg);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+}
+body.theme-dark button:not(.login-btn):hover {
+    background-color: #3a3b3f;
+}
+
+/* Summary table */
+body.theme-dark .summary-container th,
+body.theme-dark .summary-container td {
+    border-color: var(--border-color);
+    color: var(--text-color);
+}
+body.theme-dark .summary-container th {
+    background-color: var(--input-bg);
+}
+
+/* Notification banner: keep the amber accent, but dark text for contrast */
+body.theme-dark section.notification {
+    color: #1a1a1a;
+}
+
+/* Footer (base uses inline styles, so !important is required to override) */
+body.theme-dark footer {
+    border-top-color: var(--border-color) !important;
+}
+body.theme-dark footer a {
+    color: var(--muted-text) !important;
+}
+
+/* Settings page: section cards, row dividers and the weekly-schedule grid */
+body.theme-dark .settings-section {
+    border-color: var(--border-color);
+}
+body.theme-dark .field-row + .field-row,
+body.theme-dark .account-list li + li {
+    border-top-color: var(--border-color);
+}
+body.theme-dark .schedule-day {
+    border-color: var(--border-color);
+}
+body.theme-dark .schedule-day[data-state="0"] {
+    background-color: var(--input-bg);
+}
+body.theme-dark .schedule-day:hover {
+    background-color: #3a3b3f;
 }
 
 /* Animations for weather effects */


### PR DESCRIPTION
## What

Makes the **Dark** theme actually consistent. It previously only overrode a handful of elements, so the light-first base styles leaked through all over the app.

The worst offender: `main nav` sets its background with `!important` in the base styles, and the Dark override didn't match it — so **every page** had a light-grey navbar with a near-invisible "Officetracker" header in Dark mode.

## Changes

All scoped to `body.theme-dark` — Default, City Skyline and other themes are untouched.

- **Navbar** now goes dark (matched the base rule's `!important`)
- **Refined palette** into a clear elevation hierarchy: nav `#17181a` → page `#202124` → content card `#2a2b2e` → inputs `#2f3033`, with `#e3e3e3` text and a muted `#9aa0a6` for descriptions
- **Themed the previously-light surfaces:** form inputs/selects/textareas (Notes box, theme/month selects), the summary table, calendar-nav/export buttons, the weekly-schedule grid, settings section cards + dividers, footer line + links, and notification text
- Bumps `themes.css` cache-bust to `v=3`

## Test plan

- Set **Settings → Appearance → Theme → Dark**
- Check the calendar/home page and the settings page: navbar, Notes box, summary table, buttons, selects, schedule grid, footer all read as dark and legible
- Confirm Default / City Skyline themes are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
