### PR TITLE
Revert session cookie to env-specific name, accept legacy __session

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -55,8 +55,13 @@ func NewAuth(cfg config.AppConfigurer, db database.Databaser, redis *database.Re
 }
 
 func ClearCookie(cfg config.IntegratedApp, w http.ResponseWriter) {
+	expireCookie(cfg, w, cookieName(cfg))
+	expireCookie(cfg, w, legacyCookieName(cfg))
+}
+
+func expireCookie(cfg config.IntegratedApp, w http.ResponseWriter, name string) {
 	http.SetCookie(w, &http.Cookie{
-		Name:     cookieName(cfg),
+		Name:     name,
 		Value:    "",
 		Path:     util.BasePath(cfg.Domain),
 		Expires:  time.Unix(0, 0),

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -16,7 +16,11 @@ import (
 )
 
 const (
-	userCookieBase = "__session"
+	userCookieBase = "user"
+	// legacyCookieBase is the "__session" name briefly required by Firebase
+	// Hosting. Sessions issued under it are still accepted, and migrated to
+	// the current name on first sight, so they aren't invalidated.
+	legacyCookieBase = "__session"
 )
 
 func cookieName(cfg config.IntegratedApp) string {
@@ -24,6 +28,13 @@ func cookieName(cfg config.IntegratedApp) string {
 		return userCookieBase
 	}
 	return userCookieBase + "_" + cfg.App.Env
+}
+
+func legacyCookieName(cfg config.IntegratedApp) string {
+	if cfg.App.Env == "" || cfg.App.Env == "cloud" {
+		return legacyCookieBase
+	}
+	return legacyCookieBase + "_" + cfg.App.Env
 }
 
 type Method int
@@ -124,6 +135,23 @@ func issueToken(cfg config.IntegratedApp, w http.ResponseWriter, userID int) err
 	return nil
 }
 
+// MigrateLegacyCookie re-issues a session presented under the legacy cookie
+// name using the current cookie name, and expires the legacy cookie. No-op
+// unless the request authenticated via the legacy cookie alone.
+func MigrateLegacyCookie(cfg config.IntegratedApp, w http.ResponseWriter, r *http.Request, userID int) {
+	if _, err := r.Cookie(cookieName(cfg)); err == nil {
+		return
+	}
+	if _, err := r.Cookie(legacyCookieName(cfg)); err != nil {
+		return
+	}
+	if err := issueToken(cfg, w, userID); err != nil {
+		slog.Warn("failed to migrate legacy session cookie", "error", err.Error())
+		return
+	}
+	expireCookie(cfg, w, legacyCookieName(cfg))
+}
+
 func getUserIDFromToken(cfg config.IntegratedApp, token string) (int, error) {
 	claims := &tokenClaims{}
 
@@ -198,6 +226,12 @@ func validateDevSecret(secret string) string {
 func GetAuth(cfg config.IntegratedApp, r *http.Request) (string, Method) {
 	// try to get from cookie
 	cookie, err := r.Cookie(cookieName(cfg))
+	if err == nil && cookie != nil {
+		return cookie.Value, MethodSSO
+	}
+
+	// fall back to the legacy cookie name
+	cookie, err = r.Cookie(legacyCookieName(cfg))
 	if err == nil && cookie != nil {
 		return cookie.Value, MethodSSO
 	}

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -38,6 +38,24 @@ func TestCookieName(t *testing.T) {
 		env  string
 		want string
 	}{
+		{"", "user"},
+		{"cloud", "user"},
+		{"dev", "user_dev"},
+		{"staging", "user_staging"},
+	}
+	for _, c := range cases {
+		cfg := config.IntegratedApp{App: config.App{Env: c.env}}
+		if got := cookieName(cfg); got != c.want {
+			t.Errorf("cookieName(env=%q) = %q, want %q", c.env, got, c.want)
+		}
+	}
+}
+
+func TestLegacyCookieName(t *testing.T) {
+	cases := []struct {
+		env  string
+		want string
+	}{
 		{"", "__session"},
 		{"cloud", "__session"},
 		{"dev", "__session_dev"},
@@ -45,8 +63,8 @@ func TestCookieName(t *testing.T) {
 	}
 	for _, c := range cases {
 		cfg := config.IntegratedApp{App: config.App{Env: c.env}}
-		if got := cookieName(cfg); got != c.want {
-			t.Errorf("cookieName(env=%q) = %q, want %q", c.env, got, c.want)
+		if got := legacyCookieName(cfg); got != c.want {
+			t.Errorf("legacyCookieName(env=%q) = %q, want %q", c.env, got, c.want)
 		}
 	}
 }
@@ -241,6 +259,81 @@ func TestGetAuth(t *testing.T) {
 			t.Errorf("got (%q, %v), want cookie to win", tok, method)
 		}
 	})
+
+	t.Run("legacy cookie -> SSO", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		r.AddCookie(&http.Cookie{Name: legacyCookieName(cfg), Value: "legacy-token"})
+		tok, method := GetAuth(cfg, r)
+		if tok != "legacy-token" || method != MethodSSO {
+			t.Errorf("got (%q, %v), want (legacy-token, SSO)", tok, method)
+		}
+	})
+
+	t.Run("current cookie takes precedence over legacy", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		r.AddCookie(&http.Cookie{Name: cookieName(cfg), Value: "current-token"})
+		r.AddCookie(&http.Cookie{Name: legacyCookieName(cfg), Value: "legacy-token"})
+		tok, method := GetAuth(cfg, r)
+		if tok != "current-token" || method != MethodSSO {
+			t.Errorf("got (%q, %v), want current cookie to win", tok, method)
+		}
+	})
+}
+
+// A session presented under the legacy cookie name gets re-issued under the
+// current name and the legacy cookie is expired.
+func TestMigrateLegacyCookie(t *testing.T) {
+	cfg := testCfg()
+
+	t.Run("legacy only -> re-issued and legacy expired", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		r.AddCookie(&http.Cookie{Name: legacyCookieName(cfg), Value: "legacy-token"})
+		w := httptest.NewRecorder()
+		MigrateLegacyCookie(cfg, w, r, 13)
+
+		var issued, expired *http.Cookie
+		for _, c := range w.Result().Cookies() {
+			switch c.Name {
+			case cookieName(cfg):
+				issued = c
+			case legacyCookieName(cfg):
+				expired = c
+			}
+		}
+		if issued == nil {
+			t.Fatal("expected session to be re-issued under the current cookie name")
+		}
+		uid, err := getUserIDFromToken(cfg, issued.Value)
+		if err != nil || uid != 13 {
+			t.Errorf("re-issued cookie token validates to (%d, %v), want (13, nil)", uid, err)
+		}
+		if expired == nil {
+			t.Fatal("expected legacy cookie to be expired")
+		}
+		if expired.Value != "" || !expired.Expires.Before(time.Now()) {
+			t.Errorf("legacy cookie = %+v, want empty and expired", expired)
+		}
+	})
+
+	t.Run("current cookie present -> no-op", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		r.AddCookie(&http.Cookie{Name: cookieName(cfg), Value: "current-token"})
+		r.AddCookie(&http.Cookie{Name: legacyCookieName(cfg), Value: "legacy-token"})
+		w := httptest.NewRecorder()
+		MigrateLegacyCookie(cfg, w, r, 13)
+		if n := len(w.Result().Cookies()); n != 0 {
+			t.Errorf("expected no cookies set, got %d", n)
+		}
+	})
+
+	t.Run("no legacy cookie -> no-op", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+		MigrateLegacyCookie(cfg, w, r, 13)
+		if n := len(w.Result().Cookies()); n != 0 {
+			t.Errorf("expected no cookies set, got %d", n)
+		}
+	})
 }
 
 func TestMethodString(t *testing.T) {
@@ -294,24 +387,35 @@ func TestIssueTokenLocalhostDomain(t *testing.T) {
 	}
 }
 
+// ClearCookie expires the session cookie under both the current and legacy
+// names, so a legacy-cookie session can't survive a logout.
 func TestClearCookie(t *testing.T) {
 	cfg := testCfg()
 	w := httptest.NewRecorder()
 	ClearCookie(cfg, w)
 
 	cookies := w.Result().Cookies()
-	if len(cookies) != 1 {
-		t.Fatalf("expected 1 cookie, got %d", len(cookies))
+	if len(cookies) != 2 {
+		t.Fatalf("expected 2 cookies, got %d", len(cookies))
 	}
-	c := cookies[0]
-	if c.Name != cookieName(cfg) {
-		t.Errorf("cookie name = %q, want %q", c.Name, cookieName(cfg))
+	wantNames := map[string]bool{cookieName(cfg): false, legacyCookieName(cfg): false}
+	for _, c := range cookies {
+		if _, ok := wantNames[c.Name]; !ok {
+			t.Errorf("unexpected cookie %q cleared", c.Name)
+			continue
+		}
+		wantNames[c.Name] = true
+		if c.Value != "" {
+			t.Errorf("cleared cookie %q value = %q, want empty", c.Name, c.Value)
+		}
+		if !c.Expires.Before(time.Now()) {
+			t.Errorf("cleared cookie %q expiry = %v, want in the past", c.Name, c.Expires)
+		}
 	}
-	if c.Value != "" {
-		t.Errorf("cleared cookie value = %q, want empty", c.Value)
-	}
-	if !c.Expires.Before(time.Now()) {
-		t.Errorf("cleared cookie expiry = %v, want in the past", c.Expires)
+	for name, seen := range wantNames {
+		if !seen {
+			t.Errorf("cookie %q was not cleared", name)
+		}
 	}
 }
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -78,6 +78,9 @@ func injectAuth(db database.Databaser, cfger config.AppConfigurer) func(http.Han
 					// Don't set userID in context when auth fails
 				} else {
 					val.Set(context2.CtxUserIDKey, userID)
+					if authMethod == auth.MethodSSO {
+						auth.MigrateLegacyCookie(cfg, w, r, userID)
+					}
 				}
 			}
 			ctx = context.WithValue(ctx, context2.CtxKey, val)


### PR DESCRIPTION
## Summary

The `__session` cookie name was only needed for Firebase Hosting's CDN cookie passthrough, which no longer applies. This reverts to the old env-specific cookie name while keeping existing sessions alive.

- New sessions are issued under the old env-specific name (`user`, `user_dev`, `user_staging`; bare `user` on cloud/prod)
- Existing `__session` cookies (env-specific variants included) are still accepted as a fallback in `GetAuth`
- On the first authenticated request with a legacy-only cookie, the session is transparently re-issued under the current name and the `__session` cookie is expired — no sessions invalidated
- `ClearCookie` (logout / invalid token) now expires both names, so a legacy cookie can't survive a logout

Once active sessions have cycled through (30-day expiry), the legacy path can be deleted wholesale: `legacyCookieBase`, `legacyCookieName`, `MigrateLegacyCookie`, and their call sites.

The `Cache-Control: private, no-store` header from the original cookie commit is left in place — it's correct regardless of cookie name.

## Testing

- Restored `user`/`user_dev` expectations in `TestCookieName`
- New coverage: legacy fallback, current-over-legacy precedence, migration (re-issue + expiry, no-op cases), dual clearing
- Full test suite and `go vet` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)