### PR TITLE
Mobile: catch up with web — attendance target + matching page layout

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -9,16 +9,20 @@ import { AUTH0_CLIENT_ID, AUTH0_DOMAIN } from './src/config';
 // which must happen at module load so it's available when iOS/Android relaunch
 // the app for a location event.
 import { checkProximityNow, syncWorkGeofence } from './src/location';
+import TabBar, { Tab } from './src/components/TabBar';
 import CalendarScreen from './src/screens/CalendarScreen';
 import LoginScreen from './src/screens/LoginScreen';
+import ReportScreen from './src/screens/ReportScreen';
 import SettingsScreen from './src/screens/SettingsScreen';
 import { clearConnection, Connection, loadConnection } from './src/storage';
 import { colors } from './src/theme';
 
-type Screen = 'loading' | 'login' | 'calendar' | 'settings';
+type Screen = 'loading' | 'login' | 'app';
 
 export default function App() {
   const [screen, setScreen] = useState<Screen>('loading');
+  // Which of the three pages the bottom tab bar shows when connected.
+  const [tab, setTab] = useState<Tab>('calendar');
   const [conn, setConn] = useState<Connection | null>(null);
   const [fontsLoaded] = useFonts({ Calistoga_400Regular });
   // Dedupes concurrent 401s so we only sign out / alert once.
@@ -27,7 +31,7 @@ export default function App() {
   useEffect(() => {
     loadConnection().then((c) => {
       setConn(c);
-      setScreen(c ? 'calendar' : 'login');
+      setScreen(c ? 'app' : 'login');
     });
   }, []);
 
@@ -60,7 +64,8 @@ export default function App() {
   const onConnected = useCallback((c: Connection) => {
     signingOut.current = false;
     setConn(c);
-    setScreen('calendar');
+    setTab('calendar');
+    setScreen('app');
   }, []);
 
   // Hold on the spinner until both the saved session and the brand font are ready.
@@ -77,26 +82,29 @@ export default function App() {
         <LoginScreen initialBaseUrl={conn?.baseUrl} onConnected={onConnected} />
       );
       break;
-    case 'calendar':
+    case 'app':
       body = conn ? (
-        <CalendarScreen
-          conn={conn}
-          onOpenSettings={() => setScreen('settings')}
-          onUnauthorized={handleUnauthorized}
-        />
-      ) : null;
-      break;
-    case 'settings':
-      body = conn ? (
-        <SettingsScreen
-          conn={conn}
-          onClose={() => setScreen('calendar')}
-          onUnauthorized={handleUnauthorized}
-          onDisconnect={() => {
-            setConn(null);
-            setScreen('login');
-          }}
-        />
+        <View style={styles.app}>
+          <View style={styles.page}>
+            {tab === 'calendar' && (
+              <CalendarScreen conn={conn} onUnauthorized={handleUnauthorized} />
+            )}
+            {tab === 'report' && (
+              <ReportScreen conn={conn} onUnauthorized={handleUnauthorized} />
+            )}
+            {tab === 'settings' && (
+              <SettingsScreen
+                conn={conn}
+                onUnauthorized={handleUnauthorized}
+                onDisconnect={() => {
+                  setConn(null);
+                  setScreen('login');
+                }}
+              />
+            )}
+          </View>
+          <TabBar active={tab} onSelect={setTab} />
+        </View>
       ) : null;
       break;
   }
@@ -116,4 +124,6 @@ export default function App() {
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: colors.bg },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  app: { flex: 1 },
+  page: { flex: 1 },
 });

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@expo-google-fonts/calistoga": "^0.4.1",
+        "@expo/vector-icons": "^15.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",
         "expo": "~56.0.11",
         "expo-dev-client": "~56.0.20",
@@ -1478,6 +1479,17 @@
       "resolved": "https://registry.npmjs.org/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
       "license": "MIT"
+    },
+    "node_modules/@expo/vector-icons": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
+      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/@expo/xcpretty": {
       "version": "4.4.4",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -4,6 +4,7 @@
   "main": "index.ts",
   "dependencies": {
     "@expo-google-fonts/calistoga": "^0.4.1",
+    "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "expo": "~56.0.11",
     "expo-dev-client": "~56.0.20",

--- a/mobile/src/api.ts
+++ b/mobile/src/api.ts
@@ -40,6 +40,8 @@ export interface Settings {
   schedule: SchedulePreferences;
   // Month (1-12) the tracking year starts on (default October = 10).
   trackingYearStartMonth: number;
+  // Monthly attendance target percentage (0 = no target set).
+  targetPercent: number;
 }
 
 export interface TokenInfo {
@@ -252,6 +254,7 @@ export class Api {
       linked_accounts?: { provider: string; provider_display: string; nickname: string }[];
       schedule_preferences?: Partial<Record<Weekday, number>>;
       calendar_preferences?: { tracking_year_start_month?: number };
+      target_preferences?: { target_percent?: number };
     };
     const sp = p.schedule_preferences ?? {};
     const schedule = emptySchedule();
@@ -264,7 +267,9 @@ export class Api {
       nickname: a.nickname,
     }));
     const startMonth = p.calendar_preferences?.tracking_year_start_month ?? 10;
-    return { linkedAccounts, schedule, trackingYearStartMonth: startMonth };
+    // Servers that predate the target feature simply omit the field: 0 = no target.
+    const targetPercent = p.target_preferences?.target_percent ?? 0;
+    return { linkedAccounts, schedule, trackingYearStartMonth: startMonth, targetPercent };
   }
 
   async updateSchedule(schedule: SchedulePreferences): Promise<void> {
@@ -280,6 +285,15 @@ export class Api {
       method: 'PUT',
       headers: this.headers(true),
       body: JSON.stringify({ data: { tracking_year_start_month: startMonth } }),
+    });
+  }
+
+  // Saves the monthly attendance target percentage (0 clears the target).
+  async updateTargetPercent(percent: number): Promise<void> {
+    await this.request('/api/v1/settings/target', {
+      method: 'PUT',
+      headers: this.headers(true),
+      body: JSON.stringify({ data: { target_percent: percent } }),
     });
   }
 

--- a/mobile/src/components/Summary.tsx
+++ b/mobile/src/components/Summary.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { formatPercent, Stats } from '../stats';
-import { colors, spacing } from '../theme';
+import { colors, radius, spacing } from '../theme';
 
 // One row per tracking-year month, mirroring the web summary table.
 export interface SummaryRow {
@@ -31,16 +31,16 @@ function Row({
   return (
     <View style={[styles.row, last && styles.rowLast]}>
       {cells.map((c, i) => (
-        <View
-          key={i}
-          style={[
-            styles.cell,
-            { flex: COLS[i] },
-            i < cells.length - 1 && styles.cellDivider,
-            header && styles.headerCell,
-          ]}
-        >
-          <Text style={[styles.cellText, header && styles.headerText]}>{c}</Text>
+        <View key={i} style={[styles.cell, { flex: COLS[i] }]}>
+          <Text
+            style={[
+              styles.cellText,
+              i > 0 && styles.numText,
+              header && styles.headerText,
+            ]}
+          >
+            {c}
+          </Text>
         </View>
       ))}
     </View>
@@ -85,36 +85,34 @@ const styles = StyleSheet.create({
     lineHeight: 21,
   },
   table: {
-    borderWidth: 1,
-    borderColor: colors.border,
+    backgroundColor: colors.cellBg,
+    borderRadius: radius.lg,
+    paddingHorizontal: spacing.xs,
     overflow: 'hidden',
   },
   row: {
     flexDirection: 'row',
-    borderBottomWidth: 1,
+    borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: colors.border,
   },
   rowLast: {
     borderBottomWidth: 0,
   },
   cell: {
-    paddingVertical: spacing.sm,
+    paddingVertical: spacing.md,
     paddingHorizontal: spacing.sm,
     justifyContent: 'center',
   },
-  cellDivider: {
-    borderRightWidth: 1,
-    borderRightColor: colors.border,
-  },
-  headerCell: {
-    backgroundColor: colors.tableHeaderBg,
-  },
   cellText: {
-    fontSize: 13,
+    fontSize: 14,
     color: colors.textMuted,
   },
+  numText: {
+    textAlign: 'right',
+    fontVariant: ['tabular-nums'],
+  },
   headerText: {
-    fontWeight: '700',
+    fontWeight: '600',
     color: colors.text,
   },
 });

--- a/mobile/src/components/TabBar.tsx
+++ b/mobile/src/components/TabBar.tsx
@@ -1,3 +1,4 @@
+import { Ionicons } from '@expo/vector-icons';
 import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -5,10 +6,12 @@ import { colors, spacing } from '../theme';
 
 export type Tab = 'calendar' | 'report' | 'settings';
 
-const TABS: { key: Tab; label: string }[] = [
-  { key: 'calendar', label: 'Calendar' },
-  { key: 'report', label: 'Report' },
-  { key: 'settings', label: 'Settings' },
+type IconName = keyof typeof Ionicons.glyphMap;
+
+const TABS: { key: Tab; label: string; icon: IconName; iconActive: IconName }[] = [
+  { key: 'calendar', label: 'Calendar', icon: 'calendar-outline', iconActive: 'calendar' },
+  { key: 'report', label: 'Report', icon: 'stats-chart-outline', iconActive: 'stats-chart' },
+  { key: 'settings', label: 'Settings', icon: 'settings-outline', iconActive: 'settings' },
 ];
 
 interface Props {
@@ -16,23 +19,31 @@ interface Props {
   onSelect: (tab: Tab) => void;
 }
 
-// Flat bottom bar in the brand block colour, mirroring the web navbar's
-// plain-language links; the active tab is accented.
+// Native-style bottom tab bar in the brand block colour: icon over a small
+// label, the active tab accented.
 export default function TabBar({ active, onSelect }: Props) {
   const insets = useSafeAreaInsets();
   return (
     <View style={[styles.bar, { paddingBottom: insets.bottom }]}>
-      {TABS.map((t) => (
-        <Pressable
-          key={t.key}
-          style={({ pressed }) => [styles.tab, pressed && styles.pressed]}
-          onPress={() => onSelect(t.key)}
-        >
-          <Text style={[styles.label, active === t.key && styles.labelActive]}>
-            {t.label}
-          </Text>
-        </Pressable>
-      ))}
+      {TABS.map((t) => {
+        const selected = active === t.key;
+        return (
+          <Pressable
+            key={t.key}
+            style={({ pressed }) => [styles.tab, pressed && styles.pressed]}
+            onPress={() => onSelect(t.key)}
+          >
+            <Ionicons
+              name={selected ? t.iconActive : t.icon}
+              size={24}
+              color={selected ? colors.accent : colors.textFaint}
+            />
+            <Text style={[styles.label, selected && styles.labelActive]}>
+              {t.label}
+            </Text>
+          </Pressable>
+        );
+      })}
     </View>
   );
 }
@@ -41,19 +52,23 @@ const styles = StyleSheet.create({
   bar: {
     flexDirection: 'row',
     backgroundColor: colors.navBg,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.border,
   },
   tab: {
     flex: 1,
     alignItems: 'center',
-    paddingVertical: spacing.md,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.xs,
+    gap: 2,
   },
   pressed: { opacity: 0.6 },
   label: {
-    fontSize: 15,
-    color: colors.textMuted,
+    fontSize: 11,
+    color: colors.textFaint,
   },
   labelActive: {
     color: colors.accent,
-    fontWeight: '700',
+    fontWeight: '600',
   },
 });

--- a/mobile/src/components/TabBar.tsx
+++ b/mobile/src/components/TabBar.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { colors, spacing } from '../theme';
+
+export type Tab = 'calendar' | 'report' | 'settings';
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: 'calendar', label: 'Calendar' },
+  { key: 'report', label: 'Report' },
+  { key: 'settings', label: 'Settings' },
+];
+
+interface Props {
+  active: Tab;
+  onSelect: (tab: Tab) => void;
+}
+
+// Flat bottom bar in the brand block colour, mirroring the web navbar's
+// plain-language links; the active tab is accented.
+export default function TabBar({ active, onSelect }: Props) {
+  const insets = useSafeAreaInsets();
+  return (
+    <View style={[styles.bar, { paddingBottom: insets.bottom }]}>
+      {TABS.map((t) => (
+        <Pressable
+          key={t.key}
+          style={({ pressed }) => [styles.tab, pressed && styles.pressed]}
+          onPress={() => onSelect(t.key)}
+        >
+          <Text style={[styles.label, active === t.key && styles.labelActive]}>
+            {t.label}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: 'row',
+    backgroundColor: colors.navBg,
+  },
+  tab: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+  },
+  pressed: { opacity: 0.6 },
+  label: {
+    fontSize: 15,
+    color: colors.textMuted,
+  },
+  labelActive: {
+    color: colors.accent,
+    fontWeight: '700',
+  },
+});

--- a/mobile/src/components/TargetBox.tsx
+++ b/mobile/src/components/TargetBox.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { MonthDays } from '../api';
+import { targetProgress } from '../stats';
+import { colors, spacing } from '../theme';
+
+interface Props {
+  days: MonthDays;
+  targetPercent: number; // 0 = no target set
+  year: number;
+  month: number; // 1-12
+}
+
+// Monthly attendance target progress for the viewed month, mirroring the web
+// form page's target box: days-needed first, then tracked progress.
+function TargetBox({ days, targetPercent, year, month }: Props) {
+  if (targetPercent <= 0) {
+    return (
+      <View style={styles.box}>
+        <Text style={styles.line}>
+          No monthly attendance target set. You can set one in Settings.
+        </Text>
+      </View>
+    );
+  }
+
+  const p = targetProgress(days, targetPercent, year, month);
+  return (
+    <View style={styles.box}>
+      <Text style={styles.line}>
+        {p.needed > 0 ? (
+          <>
+            <Text style={styles.num}>{p.needed}</Text> more office{' '}
+            {p.needed === 1 ? 'day' : 'days'} needed this month.
+          </>
+        ) : (
+          'Target met for this month.'
+        )}
+      </Text>
+      <Text style={styles.line}>
+        In office <Text style={styles.num}>{p.office}</Text> of{' '}
+        <Text style={styles.num}>{p.total}</Text> tracked days (
+        <Text style={styles.num}>{p.percent.toFixed(1)}%</Text>).
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  box: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: spacing.md,
+    gap: spacing.xs,
+  },
+  line: {
+    fontSize: 14,
+    color: colors.text,
+    lineHeight: 20,
+  },
+  num: {
+    fontWeight: '600',
+  },
+});
+
+export default React.memo(TargetBox);

--- a/mobile/src/components/TargetBox.tsx
+++ b/mobile/src/components/TargetBox.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { MonthDays } from '../api';
 import { targetProgress } from '../stats';
-import { colors, spacing } from '../theme';
+import { colors, radius, spacing } from '../theme';
 
 interface Props {
   days: MonthDays;
@@ -48,9 +48,9 @@ function TargetBox({ days, targetPercent, year, month }: Props) {
 
 const styles = StyleSheet.create({
   box: {
-    borderWidth: 1,
-    borderColor: colors.border,
-    padding: spacing.md,
+    backgroundColor: colors.cellBg,
+    borderRadius: radius.lg,
+    padding: spacing.lg,
     gap: spacing.xs,
   },
   line: {

--- a/mobile/src/screens/CalendarScreen.tsx
+++ b/mobile/src/screens/CalendarScreen.tsx
@@ -17,6 +17,7 @@ import Header from '../components/Header';
 import Legend from '../components/Legend';
 import LocationPicker, { Coord } from '../components/LocationPicker';
 import Summary, { SummaryRow } from '../components/Summary';
+import TargetBox from '../components/TargetBox';
 import WorkLocationBanner from '../components/WorkLocationBanner';
 import {
   addMonths,
@@ -63,6 +64,8 @@ export default function CalendarScreen({
 
   const [view, setView] = useState<ViewMonth>(thisMonth());
   const [startMonth, setStartMonth] = useState(DEFAULT_TRACKING_YEAR_START_MONTH);
+  // Monthly attendance target (0 = none), fetched with the rest of settings.
+  const [targetPercent, setTargetPercent] = useState(0);
   const fy = trackingYear(view.year, view.month, startMonth);
 
   // Loaded tracking year, keyed month (1-12) -> day -> state.
@@ -132,7 +135,10 @@ export default function CalendarScreen({
     new Api(conn)
       .getSettings()
       .then((s) => {
-        if (!cancelled) setStartMonth(s.trackingYearStartMonth);
+        if (!cancelled) {
+          setStartMonth(s.trackingYearStartMonth);
+          setTargetPercent(s.targetPercent);
+        }
         // Cache for the background geofence task, which can't fetch settings.
         cacheStartMonth(s.trackingYearStartMonth);
       })
@@ -379,6 +385,20 @@ export default function CalendarScreen({
               textAlignVertical="top"
             />
           </View>
+
+          {/* On a read-only server there's no way to set a target, so only
+              show the section when one exists. */}
+          {(!readOnly || targetPercent > 0) && (
+            <View style={styles.section}>
+              <Text style={styles.heading}>Target</Text>
+              <TargetBox
+                days={days}
+                targetPercent={targetPercent}
+                year={view.year}
+                month={view.month}
+              />
+            </View>
+          )}
 
           <View style={styles.section}>
             <Text style={styles.heading}>Summary</Text>

--- a/mobile/src/screens/CalendarScreen.tsx
+++ b/mobile/src/screens/CalendarScreen.tsx
@@ -1,3 +1,4 @@
+import { Ionicons } from '@expo/vector-icons';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
@@ -302,7 +303,7 @@ export default function CalendarScreen({ conn, onUnauthorized }: Props) {
           style={({ pressed }) => [styles.navBtn, pressed && styles.pressed]}
           hitSlop={8}
         >
-          <Text style={styles.navText}>‹</Text>
+          <Ionicons name="chevron-back" size={22} color={colors.text} />
         </Pressable>
         <Pressable onPress={goToday} hitSlop={8}>
           <Text style={styles.monthYear}>
@@ -314,7 +315,7 @@ export default function CalendarScreen({ conn, onUnauthorized }: Props) {
           style={({ pressed }) => [styles.navBtn, pressed && styles.pressed]}
           hitSlop={8}
         >
-          <Text style={styles.navText}>›</Text>
+          <Ionicons name="chevron-forward" size={22} color={colors.text} />
         </Pressable>
       </View>
 
@@ -415,15 +416,8 @@ const styles = StyleSheet.create({
     height: 36,
     alignItems: 'center',
     justifyContent: 'center',
-    borderWidth: 1,
-    borderColor: colors.border,
     borderRadius: radius.md,
     backgroundColor: colors.cellBg,
-  },
-  navText: {
-    fontSize: 22,
-    color: colors.text,
-    lineHeight: 24,
   },
   monthYear: {
     fontSize: 22,
@@ -444,9 +438,8 @@ const styles = StyleSheet.create({
     marginBottom: spacing.md,
   },
   retry: {
-    borderWidth: 1,
-    borderColor: colors.border,
     borderRadius: radius.md,
+    backgroundColor: colors.cellBg,
     paddingVertical: spacing.sm,
     paddingHorizontal: spacing.lg,
   },
@@ -475,10 +468,8 @@ const styles = StyleSheet.create({
   },
   notes: {
     minHeight: 96,
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: radius.md,
-    padding: spacing.md,
+    borderRadius: radius.lg,
+    padding: spacing.lg,
     fontSize: 15,
     color: colors.text,
     backgroundColor: colors.fieldBg,

--- a/mobile/src/screens/CalendarScreen.tsx
+++ b/mobile/src/screens/CalendarScreen.tsx
@@ -16,22 +16,18 @@ import Calendar from '../components/Calendar';
 import Header from '../components/Header';
 import Legend from '../components/Legend';
 import LocationPicker, { Coord } from '../components/LocationPicker';
-import Summary, { SummaryRow } from '../components/Summary';
 import TargetBox from '../components/TargetBox';
 import WorkLocationBanner from '../components/WorkLocationBanner';
 import {
   addMonths,
-  calendarYearForMonth,
   DEFAULT_TRACKING_YEAR_START_MONTH,
   formatMonthYear,
   MONTH_NAMES,
   thisMonth,
-  trackingMonthOrder,
   trackingYear,
   ViewMonth,
 } from '../dates';
 import { enableWorkTracking } from '../location';
-import { monthStats, yearStats } from '../stats';
 import { AttendanceState, cycleState } from '../states';
 import {
   cacheStartMonth,
@@ -45,15 +41,10 @@ import { colors, radius, spacing } from '../theme';
 
 interface Props {
   conn: Connection;
-  onOpenSettings: () => void;
   onUnauthorized: () => void;
 }
 
-export default function CalendarScreen({
-  conn,
-  onOpenSettings,
-  onUnauthorized,
-}: Props) {
+export default function CalendarScreen({ conn, onUnauthorized }: Props) {
   const api = useMemo(
     () => new Api(conn, onUnauthorized),
     [conn, onUnauthorized],
@@ -241,7 +232,7 @@ export default function CalendarScreen({
     });
   }, [api, noteText, notes, view, readOnly]);
 
-  // Save any pending note before leaving the current month/screen.
+  // Save any pending note before leaving the current month.
   const go = (delta: number) => {
     saveNote();
     setView((v) => addMonths(v, delta));
@@ -250,30 +241,17 @@ export default function CalendarScreen({
     saveNote();
     setView(thisMonth());
   };
-  const openSettings = () => {
-    saveNote();
-    onOpenSettings();
-  };
 
-  const year = useMemo(() => yearStats(yearData), [yearData]);
-
-  // One row per tracked month, ordered start-month-first, mirroring the web
-  // summary table.
-  const summaryRows = useMemo<SummaryRow[]>(() => {
-    return Object.keys(yearData)
-      .map(Number)
-      .map((m) => {
-        const s = monthStats(yearData[m] ?? {});
-        const calYear = calendarYearForMonth(m, fy, startMonth);
-        return { label: `${MONTH_NAMES[m - 1]} ${calYear}`, ...s, month: m };
-      })
-      .filter((r) => r.total > 0)
-      .sort(
-        (a, b) =>
-          trackingMonthOrder(a.month, startMonth) -
-          trackingMonthOrder(b.month, startMonth),
-      );
-  }, [yearData, fy, startMonth]);
+  // Switching tabs unmounts this screen before the note field can blur, so
+  // flush any pending note on unmount too (via a ref to dodge a stale closure).
+  const saveNoteRef = useRef(saveNote);
+  saveNoteRef.current = saveNote;
+  useEffect(
+    () => () => {
+      saveNoteRef.current();
+    },
+    [],
+  );
 
   // Swipe the calendar left/right to change months. Built once; reads the
   // latest navigation handler through a ref to avoid a stale closure.
@@ -295,7 +273,7 @@ export default function CalendarScreen({
   return (
     <View style={styles.screen}>
       {/* Fixed nav bar — pull-to-refresh only scrolls the content below it. */}
-      <Header rightLabel="Settings" onRightPress={openSettings} />
+      <Header />
 
       <ScrollView
         style={styles.flex}
@@ -399,11 +377,6 @@ export default function CalendarScreen({
               />
             </View>
           )}
-
-          <View style={styles.section}>
-            <Text style={styles.heading}>Summary</Text>
-            <Summary rows={summaryRows} total={year} />
-          </View>
         </>
       )}
         </View>

--- a/mobile/src/screens/ReportScreen.tsx
+++ b/mobile/src/screens/ReportScreen.tsx
@@ -1,3 +1,4 @@
+import { Ionicons } from '@expo/vector-icons';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
@@ -9,7 +10,6 @@ import {
   View,
 } from 'react-native';
 import { Api, MonthDays } from '../api';
-import Header from '../components/Header';
 import Summary, { SummaryRow } from '../components/Summary';
 import {
   calendarYearForMonth,
@@ -110,9 +110,6 @@ export default function ReportScreen({ conn, onUnauthorized }: Props) {
 
   return (
     <View style={styles.screen}>
-      {/* Fixed nav bar — pull-to-refresh only scrolls the content below it. */}
-      <Header />
-
       <ScrollView
         style={styles.flex}
         contentContainerStyle={styles.content}
@@ -125,25 +122,28 @@ export default function ReportScreen({ conn, onUnauthorized }: Props) {
         }
       >
         <View style={styles.body}>
-          <View style={styles.yearNav}>
-            <Pressable
-              onPress={() => setFySel(fy - 1)}
-              style={({ pressed }) => [styles.navBtn, pressed && styles.pressed]}
-              hitSlop={8}
-            >
-              <Text style={styles.navText}>‹</Text>
-            </Pressable>
-            {/* Tap the year to jump back to the current tracking year. */}
-            <Pressable onPress={() => setFySel(null)} hitSlop={8}>
-              <Text style={styles.year}>{fy}</Text>
-            </Pressable>
-            <Pressable
-              onPress={() => setFySel(fy + 1)}
-              style={({ pressed }) => [styles.navBtn, pressed && styles.pressed]}
-              hitSlop={8}
-            >
-              <Text style={styles.navText}>›</Text>
-            </Pressable>
+          <View style={styles.titleRow}>
+            <Text style={styles.title}>Report</Text>
+            <View style={styles.yearNav}>
+              <Pressable
+                onPress={() => setFySel(fy - 1)}
+                style={({ pressed }) => [styles.navBtn, pressed && styles.pressed]}
+                hitSlop={8}
+              >
+                <Ionicons name="chevron-back" size={20} color={colors.text} />
+              </Pressable>
+              {/* Tap the year to jump back to the current tracking year. */}
+              <Pressable onPress={() => setFySel(null)} hitSlop={8}>
+                <Text style={styles.year}>{fy}</Text>
+              </Pressable>
+              <Pressable
+                onPress={() => setFySel(fy + 1)}
+                style={({ pressed }) => [styles.navBtn, pressed && styles.pressed]}
+                hitSlop={8}
+              >
+                <Ionicons name="chevron-forward" size={20} color={colors.text} />
+              </Pressable>
+            </View>
           </View>
 
           {loading ? (
@@ -159,7 +159,6 @@ export default function ReportScreen({ conn, onUnauthorized }: Props) {
             </View>
           ) : (
             <View style={styles.section}>
-              <Text style={styles.heading}>Summary</Text>
               <Summary rows={rows} total={total} />
             </View>
           )}
@@ -174,32 +173,36 @@ const styles = StyleSheet.create({
   flex: { flex: 1, backgroundColor: colors.surface },
   content: { paddingBottom: spacing.xl * 2 },
   body: { padding: spacing.lg },
-  yearNav: {
+  titleRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    marginTop: spacing.lg,
-    marginBottom: spacing.md,
+    marginTop: spacing.sm,
+    marginBottom: spacing.lg,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  yearNav: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
   },
   navBtn: {
-    width: 44,
-    height: 36,
+    width: 36,
+    height: 32,
     alignItems: 'center',
     justifyContent: 'center',
-    borderWidth: 1,
-    borderColor: colors.border,
     borderRadius: radius.md,
     backgroundColor: colors.cellBg,
   },
-  navText: {
-    fontSize: 22,
-    color: colors.text,
-    lineHeight: 24,
-  },
   year: {
-    fontSize: 22,
-    fontWeight: '700',
+    fontSize: 17,
+    fontWeight: '600',
     color: colors.text,
+    fontVariant: ['tabular-nums'],
   },
   pressed: { opacity: 0.6 },
   loading: { paddingVertical: spacing.xl * 2 },
@@ -213,9 +216,8 @@ const styles = StyleSheet.create({
     marginBottom: spacing.md,
   },
   retry: {
-    borderWidth: 1,
-    borderColor: colors.border,
     borderRadius: radius.md,
+    backgroundColor: colors.cellBg,
     paddingVertical: spacing.sm,
     paddingHorizontal: spacing.lg,
   },
@@ -223,11 +225,5 @@ const styles = StyleSheet.create({
     color: colors.text,
     fontWeight: '600',
   },
-  section: { marginTop: spacing.md },
-  heading: {
-    fontSize: 18,
-    fontWeight: '700',
-    color: colors.text,
-    marginBottom: spacing.sm,
-  },
+  section: { marginTop: spacing.xs },
 });

--- a/mobile/src/screens/ReportScreen.tsx
+++ b/mobile/src/screens/ReportScreen.tsx
@@ -1,0 +1,233 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { Api, MonthDays } from '../api';
+import Header from '../components/Header';
+import Summary, { SummaryRow } from '../components/Summary';
+import {
+  calendarYearForMonth,
+  DEFAULT_TRACKING_YEAR_START_MONTH,
+  MONTH_NAMES,
+  thisMonth,
+  trackingMonthOrder,
+  trackingYear,
+} from '../dates';
+import { monthStats, yearStats } from '../stats';
+import { Connection } from '../storage';
+import { colors, radius, spacing } from '../theme';
+
+interface Props {
+  conn: Connection;
+  onUnauthorized: () => void;
+}
+
+// The yearly report, mirroring the web /report page: prev/next tracking-year
+// navigation above the summary table.
+export default function ReportScreen({ conn, onUnauthorized }: Props) {
+  const api = useMemo(
+    () => new Api(conn, onUnauthorized),
+    [conn, onUnauthorized],
+  );
+
+  const [startMonth, setStartMonth] = useState(DEFAULT_TRACKING_YEAR_START_MONTH);
+  // null = the current tracking year, which can shift once the user's start
+  // month loads; set explicitly when the user navigates.
+  const [fySel, setFySel] = useState<number | null>(null);
+  const now = thisMonth();
+  const fy = fySel ?? trackingYear(now.year, now.month, startMonth);
+
+  const [yearData, setYearData] = useState<Record<number, MonthDays>>({});
+  const [loadedFy, setLoadedFy] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Best-effort fetch of the start month. Plain Api (no onUnauthorized) so an
+  // older server that 401s /settings just keeps the default instead of logging out.
+  useEffect(() => {
+    let cancelled = false;
+    new Api(conn)
+      .getSettings()
+      .then((s) => {
+        if (!cancelled) setStartMonth(s.trackingYearStartMonth);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [conn]);
+
+  const load = useCallback(
+    async (targetFy: number, isRefresh = false) => {
+      if (isRefresh) setRefreshing(true);
+      else setLoading(true);
+      setError(null);
+      try {
+        setYearData(await api.getYear(targetFy));
+        setLoadedFy(targetFy);
+      } catch (e: any) {
+        setError(e?.message ?? 'Failed to load data.');
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [api],
+  );
+
+  useEffect(() => {
+    if (loadedFy !== fy) {
+      load(fy);
+    }
+  }, [fy, loadedFy, load]);
+
+  const total = useMemo(() => yearStats(yearData), [yearData]);
+
+  // One row per tracked month, ordered start-month-first, mirroring the web
+  // report table.
+  const rows = useMemo<SummaryRow[]>(() => {
+    return Object.keys(yearData)
+      .map(Number)
+      .map((m) => {
+        const s = monthStats(yearData[m] ?? {});
+        const calYear = calendarYearForMonth(m, fy, startMonth);
+        return { label: `${MONTH_NAMES[m - 1]} ${calYear}`, ...s, month: m };
+      })
+      .filter((r) => r.total > 0)
+      .sort(
+        (a, b) =>
+          trackingMonthOrder(a.month, startMonth) -
+          trackingMonthOrder(b.month, startMonth),
+      );
+  }, [yearData, fy, startMonth]);
+
+  return (
+    <View style={styles.screen}>
+      {/* Fixed nav bar — pull-to-refresh only scrolls the content below it. */}
+      <Header />
+
+      <ScrollView
+        style={styles.flex}
+        contentContainerStyle={styles.content}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => load(fy, true)}
+            tintColor={colors.textMuted}
+          />
+        }
+      >
+        <View style={styles.body}>
+          <View style={styles.yearNav}>
+            <Pressable
+              onPress={() => setFySel(fy - 1)}
+              style={({ pressed }) => [styles.navBtn, pressed && styles.pressed]}
+              hitSlop={8}
+            >
+              <Text style={styles.navText}>‹</Text>
+            </Pressable>
+            {/* Tap the year to jump back to the current tracking year. */}
+            <Pressable onPress={() => setFySel(null)} hitSlop={8}>
+              <Text style={styles.year}>{fy}</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => setFySel(fy + 1)}
+              style={({ pressed }) => [styles.navBtn, pressed && styles.pressed]}
+              hitSlop={8}
+            >
+              <Text style={styles.navText}>›</Text>
+            </Pressable>
+          </View>
+
+          {loading ? (
+            <View style={styles.loading}>
+              <ActivityIndicator color={colors.textMuted} />
+            </View>
+          ) : error ? (
+            <View style={styles.errorBox}>
+              <Text style={styles.errorText}>{error}</Text>
+              <Pressable onPress={() => load(fy)} style={styles.retry}>
+                <Text style={styles.retryText}>Retry</Text>
+              </Pressable>
+            </View>
+          ) : (
+            <View style={styles.section}>
+              <Text style={styles.heading}>Summary</Text>
+              <Summary rows={rows} total={total} />
+            </View>
+          )}
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: colors.surface },
+  flex: { flex: 1, backgroundColor: colors.surface },
+  content: { paddingBottom: spacing.xl * 2 },
+  body: { padding: spacing.lg },
+  yearNav: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: spacing.lg,
+    marginBottom: spacing.md,
+  },
+  navBtn: {
+    width: 44,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    backgroundColor: colors.cellBg,
+  },
+  navText: {
+    fontSize: 22,
+    color: colors.text,
+    lineHeight: 24,
+  },
+  year: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  pressed: { opacity: 0.6 },
+  loading: { paddingVertical: spacing.xl * 2 },
+  errorBox: {
+    paddingVertical: spacing.xl,
+    alignItems: 'center',
+  },
+  errorText: {
+    color: colors.danger,
+    textAlign: 'center',
+    marginBottom: spacing.md,
+  },
+  retry: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.lg,
+  },
+  retryText: {
+    color: colors.text,
+    fontWeight: '600',
+  },
+  section: { marginTop: spacing.md },
+  heading: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text,
+    marginBottom: spacing.sm,
+  },
+});

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -31,7 +31,6 @@ import { colors, radius, spacing } from '../theme';
 
 interface Props {
   conn: Connection;
-  onClose: () => void;
   onUnauthorized: () => void;
   onDisconnect: () => void;
 }
@@ -46,7 +45,6 @@ const TARGET_OPTIONS = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
 
 export default function SettingsScreen({
   conn,
-  onClose,
   onUnauthorized,
   onDisconnect,
 }: Props) {
@@ -271,7 +269,7 @@ export default function SettingsScreen({
   return (
     <View style={styles.screen}>
       {/* Fixed nav bar — pull-to-refresh only scrolls the content below it. */}
-      <Header rightLabel="Done" onRightPress={onClose} />
+      <Header />
 
       <ScrollView
         style={styles.flex}

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -12,7 +12,6 @@ import {
   View,
 } from 'react-native';
 import { Api, isUnauthorized, Settings, TokenInfo, Weekday } from '../api';
-import Header from '../components/Header';
 import Legend from '../components/Legend';
 import LocationPicker, { Coord } from '../components/LocationPicker';
 import ScheduleEditor from '../components/ScheduleEditor';
@@ -268,9 +267,6 @@ export default function SettingsScreen({
 
   return (
     <View style={styles.screen}>
-      {/* Fixed nav bar — pull-to-refresh only scrolls the content below it. */}
-      <Header />
-
       <ScrollView
         style={styles.flex}
         contentContainerStyle={styles.content}
@@ -295,7 +291,7 @@ export default function SettingsScreen({
       ) : error ? (
         <View style={styles.card}>
           <Text style={styles.errorText}>{error}</Text>
-          <Pressable style={styles.button} onPress={() => load()}>
+          <Pressable style={[styles.button, styles.buttonInCard]} onPress={() => load()}>
             <Text style={styles.buttonText}>Retry</Text>
           </Pressable>
         </View>
@@ -449,10 +445,7 @@ export default function SettingsScreen({
                   >
                     <Text style={styles.buttonText}>Change</Text>
                   </Pressable>
-                  <Pressable
-                    style={[styles.workBtn, styles.workBtnDanger]}
-                    onPress={removeWorkLocation}
-                  >
+                  <Pressable style={styles.workBtn} onPress={removeWorkLocation}>
                     <Text style={[styles.buttonText, styles.dangerText]}>
                       Remove
                     </Text>
@@ -463,7 +456,7 @@ export default function SettingsScreen({
               <>
                 <Text style={styles.muted}>No work location set.</Text>
                 <Pressable
-                  style={styles.button}
+                  style={[styles.button, styles.buttonInCard]}
                   onPress={() => setPickerVisible(true)}
                 >
                   <Text style={styles.buttonText}>Set work location</Text>
@@ -513,7 +506,10 @@ export default function SettingsScreen({
               <Text style={styles.muted}>
                 Long-press to copy. It won't be shown again.
               </Text>
-              <Pressable style={styles.button} onPress={() => setNewSecret(null)}>
+              <Pressable
+                style={[styles.button, styles.buttonInCard]}
+                onPress={() => setNewSecret(null)}
+              >
                 <Text style={styles.buttonText}>Done</Text>
               </Pressable>
             </View>
@@ -570,7 +566,7 @@ const styles = StyleSheet.create({
   content: { paddingBottom: spacing.xl * 2 },
   body: { padding: spacing.lg },
   screenTitle: {
-    fontSize: 24,
+    fontSize: 28,
     fontWeight: '700',
     color: colors.text,
     marginTop: spacing.sm,
@@ -580,8 +576,7 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.sm,
     paddingHorizontal: spacing.md,
     borderRadius: radius.md,
-    borderWidth: 1,
-    borderColor: colors.border,
+    backgroundColor: colors.surface,
   },
   monthChipSelected: {
     backgroundColor: colors.accent,
@@ -592,9 +587,11 @@ const styles = StyleSheet.create({
   loading: { paddingVertical: spacing.xl * 2 },
   errorText: { color: colors.danger, marginBottom: spacing.md },
   sectionLabel: {
-    fontSize: 17,
-    fontWeight: '700',
-    color: colors.text,
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.textFaint,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
     marginTop: spacing.xl,
     marginBottom: spacing.sm,
   },
@@ -605,11 +602,9 @@ const styles = StyleSheet.create({
     marginBottom: spacing.sm,
   },
   card: {
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: 10,
+    borderRadius: radius.lg,
     padding: spacing.lg,
-    backgroundColor: colors.surface,
+    backgroundColor: colors.cellBg,
   },
   fieldLabel: { fontSize: 12, color: colors.textMuted, marginBottom: 2 },
   fieldValue: { fontSize: 15, color: colors.text },
@@ -617,23 +612,22 @@ const styles = StyleSheet.create({
   hr: { height: 1, backgroundColor: colors.border, marginVertical: spacing.md },
   button: {
     marginTop: spacing.md,
-    borderWidth: 1,
-    borderColor: colors.border,
     borderRadius: radius.md,
     paddingVertical: spacing.md,
     alignItems: 'center',
+    backgroundColor: colors.cellBg,
   },
   buttonText: { fontSize: 15, fontWeight: '600', color: colors.text },
+  // Buttons that sit inside a grey card need a white fill to stay visible.
+  buttonInCard: { backgroundColor: colors.surface },
   workActions: { flexDirection: 'row', gap: spacing.sm, marginTop: spacing.md },
   workBtn: {
     flex: 1,
-    borderWidth: 1,
-    borderColor: colors.border,
     borderRadius: radius.md,
     paddingVertical: spacing.md,
     alignItems: 'center',
+    backgroundColor: colors.surface,
   },
-  workBtnDanger: { borderColor: '#fecaca' },
   legendWrap: { marginTop: spacing.lg },
   tokenRow: {
     flexDirection: 'row',
@@ -656,8 +650,6 @@ const styles = StyleSheet.create({
   },
   input: {
     flex: 1,
-    borderWidth: 1,
-    borderColor: colors.border,
     borderRadius: radius.md,
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.md,
@@ -673,6 +665,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   createBtnText: { color: '#ffffff', fontSize: 15, fontWeight: '600' },
-  danger: { marginTop: spacing.xl, borderColor: '#fecaca' },
+  danger: { marginTop: spacing.xl },
   dangerText: { color: colors.danger },
 });

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -41,6 +41,9 @@ function formatDate(iso: string): string {
   return isNaN(d.getTime()) ? iso : d.toLocaleDateString();
 }
 
+// Attendance target choices, stepping by 10 like the web pickers. 0 = no target.
+const TARGET_OPTIONS = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+
 export default function SettingsScreen({
   conn,
   onClose,
@@ -121,6 +124,17 @@ export default function SettingsScreen({
     api.updateTrackingYearStartMonth(month).catch((e: any) => {
       if (isUnauthorized(e)) return;
       setSettings((s) => (s ? { ...s, trackingYearStartMonth: prev } : s));
+      Alert.alert('Could not save', e?.message ?? 'Please try again.');
+    });
+  }
+
+  function setTarget(percent: number) {
+    if (!settings || percent === settings.targetPercent) return;
+    const prev = settings.targetPercent;
+    setSettings({ ...settings, targetPercent: percent });
+    api.updateTargetPercent(percent).catch((e: any) => {
+      if (isUnauthorized(e)) return;
+      setSettings((s) => (s ? { ...s, targetPercent: prev } : s));
       Alert.alert('Could not save', e?.message ?? 'Please try again.');
     });
   }
@@ -370,6 +384,42 @@ export default function SettingsScreen({
                       ]}
                     >
                       {name.slice(0, 3)}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </ScrollView>
+          </View>
+
+          {/* Attendance target */}
+          <Text style={styles.sectionLabel}>Attendance target</Text>
+          <Text style={styles.hint}>
+            The share of work days you aim to spend in the office each month.
+            The calendar shows progress against it.
+          </Text>
+          <View style={styles.card}>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.monthRow}
+              keyboardShouldPersistTaps="handled"
+            >
+              {TARGET_OPTIONS.map((percent) => {
+                const selected = settings?.targetPercent === percent;
+                return (
+                  <Pressable
+                    key={percent}
+                    onPress={() => setTarget(percent)}
+                    disabled={readOnly}
+                    style={[styles.monthChip, selected && styles.monthChipSelected]}
+                  >
+                    <Text
+                      style={[
+                        styles.monthChipText,
+                        selected && styles.monthChipTextSelected,
+                      ]}
+                    >
+                      {percent === 0 ? 'Off' : `${percent}%`}
                     </Text>
                   </Pressable>
                 );

--- a/mobile/src/stats.ts
+++ b/mobile/src/stats.ts
@@ -1,5 +1,5 @@
 import { MonthDays } from './api';
-import { isOffice, isWorkDay } from './states';
+import { AttendanceState, isOffice, isWorkDay } from './states';
 
 export interface Stats {
   office: number; // days present in office (real + scheduled)
@@ -44,4 +44,43 @@ export function yearStats(year: Record<number, MonthDays>): Stats {
 export function formatPercent(percent: number): string {
   // Two decimals to match the web summary table.
   return `${percent.toFixed(2)}%`;
+}
+
+export interface TargetProgress extends Stats {
+  // More office days needed this month to meet the target, projected over the
+  // remaining untracked weekdays. 0 once the target is met.
+  needed: number;
+}
+
+// Progress for the viewed month against the attendance target, mirroring the
+// web form page: the month-end work-day count is what's tracked so far plus
+// remaining untracked weekdays (today included), assumed to become work days.
+export function targetProgress(
+  days: MonthDays,
+  targetPercent: number,
+  year: number,
+  month: number, // 1-12
+  now: Date = new Date(),
+): TargetProgress {
+  const tracked = monthStats(days);
+
+  let projectedTotal = tracked.total;
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const daysInMonth = new Date(year, month, 0).getDate();
+  for (let day = 1; day <= daysInMonth; day++) {
+    if ((days[day] ?? AttendanceState.Untracked) !== AttendanceState.Untracked) {
+      continue; // already tracked
+    }
+    const date = new Date(year, month - 1, day);
+    if (date < startOfToday) continue; // past untracked days don't count
+    const dow = date.getDay();
+    if (dow === 0 || dow === 6) continue; // weekends
+    projectedTotal++;
+  }
+
+  const needed = Math.max(
+    0,
+    Math.ceil((targetPercent / 100) * projectedTotal) - tracked.office,
+  );
+  return { ...tracked, needed };
 }

--- a/mobile/src/theme.ts
+++ b/mobile/src/theme.ts
@@ -39,9 +39,9 @@ export const spacing = {
   xl: 24,
 };
 
-// The web app uses a consistent 4px corner radius; keep it subtle and flat.
+// Softer corners than the web's 4px: still flat, but sized for touch UI.
 export const radius = {
-  sm: 4,
-  md: 4,
-  lg: 6,
+  sm: 6,
+  md: 10,
+  lg: 14,
 };


### PR DESCRIPTION
## Summary

The web app moved on while mobile development was paused. This catches the app up on the two app-facing changes — the monthly attendance target (#265) and the page structure — then applies a native-feel design pass.

### Attendance target

- **API** (`api.ts`): parse `target_preferences.target_percent` from `GET /api/v1/settings/` — absent on older servers means no target — and save via `PUT /api/v1/settings/target`.
- **Calendar screen**: new Target box mirroring the web form page's projection — office days needed this month (projected over remaining untracked weekdays, today included) and tracked progress so far. Hidden on read-only servers with no target set.
- **Settings screen**: new Attendance target section with Off/10–100% chips stepping by 10 (matching the web pickers), optimistic save with revert on failure.
- **Stats** (`stats.ts`): `targetProgress()` reuses the existing `isOffice`/`isWorkDay` counting, so present/total match the web exactly.

### Page layout matching the web (bottom tab bar)

- Bottom tab bar (Calendar / Report / Settings) replaces the Settings/Done header links.
- **Calendar** matches the web form page: calendar, notes and target only. Pending notes also save on unmount, since switching tabs skips the note field's blur.
- **Report** is a new tab mirroring `/report`: prev/next tracking-year navigation (tap the year to jump back to the current one) above the yearly summary table. The web page's CSV/PDF exports are omitted — they're browser downloads that can't carry the app's Bearer token.
- **Settings** becomes a tab.

### Native-feel design pass

The first cut read as a website in a wrapper; this softens the deliberate web mirroring where it fights mobile conventions, keeping the flat look and brand colour:

- Tab bar gets Ionicons icons over small labels (accent + filled variant when active) — adds `@expo/vector-icons`.
- Radius tokens 4/4/6 → 6/10/14, softening buttons, chips, inputs and day cells app-wide.
- Summary becomes an inset-grouped card (grey fill, rounded, hairline dividers, right-aligned tabular numerals) instead of a full-border web table.
- Report and Settings use native large titles; the brand bar (and its easter egg) stays on the Calendar tab only.
- Settings gets iOS-style uppercase section labels, borderless grey card groups, and filled buttons/chips instead of outlined ones.

## Drift reviewed but needing no mobile change

- Session cookie rename (#263) and `/login` → Auth0 redirect (#266): the app authenticates natively via `/auth/native` with Bearer tokens, so web session mechanics don't apply.
- Navbar/settings redesign, dark-theme fixes, Sydney cutover, dependency bumps: web/server only; the `KNOWN_SERVERS` domains are unchanged.

## Verification

Clean `tsc --noEmit` after a fresh `npm ci` in `mobile/`. Not screenshot-verified: the app needs a dev-client build (native Auth0/maps modules), which I can't run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)